### PR TITLE
Auto match system created transactions

### DIFF
--- a/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
+++ b/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Ledger\IReconciliationBuilder.cs" />
     <Compile Include="Ledger\LedgerBookFactory.cs" />
     <Compile Include="Ledger\ReconciliationBuilder.cs" />
+    <Compile Include="Ledger\ReconciliationConsistency.cs" />
     <Compile Include="Ledger\ToDoCollection.cs" />
     <Compile Include="Ledger\TodoTask.cs" />
     <Compile Include="Ledger\ToDoTaskType.cs" />

--- a/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
+++ b/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Ledger\Data\ToDoCollectionToDtoMapper.cs" />
     <Compile Include="Ledger\Data\ToDoTaskDto.cs" />
     <Compile Include="Ledger\ILedgerBookFactory.cs" />
+    <Compile Include="Ledger\IReconciliationBuilder.cs" />
     <Compile Include="Ledger\LedgerBookFactory.cs" />
     <Compile Include="Ledger\ReconciliationBuilder.cs" />
     <Compile Include="Ledger\ToDoCollection.cs" />
@@ -208,11 +209,13 @@
     <Compile Include="Matching\Data\MatchingRuleDto.cs" />
     <Compile Include="Matching\Data\DtoToMatchingRuleMapper.cs" />
     <Compile Include="Matching\Data\MatchingRuleDomainToDataMapper.cs" />
+    <Compile Include="Matching\Data\SingleUseMatchingRuleDto.cs" />
     <Compile Include="Matching\IMatchingRuleFactory.cs" />
     <Compile Include="Matching\IMatchMaker.cs" />
     <Compile Include="Matching\MatchingRuleFactory.cs" />
     <Compile Include="Matching\MatchMaker.cs" />
     <Compile Include="Matching\RulesGroupedByBucket.cs" />
+    <Compile Include="Matching\SingleUseMatchingRule.cs" />
     <Compile Include="NullLogger.cs" />
     <Compile Include="Persistence\ApplicationAutoMapperConfiguration.cs" />
     <Compile Include="Persistence\ApplicationDatabase.cs" />

--- a/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
+++ b/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
@@ -147,9 +147,11 @@
     <Compile Include="Ledger\Data\ToDoTaskDto.cs" />
     <Compile Include="Ledger\ILedgerBookFactory.cs" />
     <Compile Include="Ledger\IReconciliationBuilder.cs" />
+    <Compile Include="Ledger\IReconciliationConsistency.cs" />
     <Compile Include="Ledger\LedgerBookFactory.cs" />
     <Compile Include="Ledger\ReconciliationBuilder.cs" />
     <Compile Include="Ledger\ReconciliationConsistency.cs" />
+    <Compile Include="Ledger\ReconciliationConsistencyChecker.cs" />
     <Compile Include="Ledger\ToDoCollection.cs" />
     <Compile Include="Ledger\TodoTask.cs" />
     <Compile Include="Ledger\ToDoTaskType.cs" />

--- a/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
+++ b/BudgetAnalyser.Engine/BudgetAnalyser.Engine.csproj
@@ -145,6 +145,9 @@
     <Compile Include="Ledger\Data\LedgerTransactionFactory.cs" />
     <Compile Include="Ledger\Data\ToDoCollectionToDtoMapper.cs" />
     <Compile Include="Ledger\Data\ToDoTaskDto.cs" />
+    <Compile Include="Ledger\ILedgerBookFactory.cs" />
+    <Compile Include="Ledger\LedgerBookFactory.cs" />
+    <Compile Include="Ledger\ReconciliationBuilder.cs" />
     <Compile Include="Ledger\ToDoCollection.cs" />
     <Compile Include="Ledger\TodoTask.cs" />
     <Compile Include="Ledger\ToDoTaskType.cs" />

--- a/BudgetAnalyser.Engine/IEnumerableExtension.cs
+++ b/BudgetAnalyser.Engine/IEnumerableExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BudgetAnalyser.Engine
@@ -8,6 +9,20 @@ namespace BudgetAnalyser.Engine
         public static bool None<T>(this IEnumerable<T> instance)
         {
             return !instance.Any();
+        }
+
+        public static double SafeAverage<T>(this IEnumerable<T> instance, Func<T, double> selector)
+        {
+            var copy = instance.ToList();
+            if (copy.None()) return 0;
+            return copy.Average(selector);
+        }
+
+        public static decimal SafeAverage<T>(this IEnumerable<T> instance, Func<T, decimal> selector)
+        {
+            var copy = instance.ToList();
+            if (copy.None()) return 0;
+            return copy.Average(selector);
         }
     }
 }

--- a/BudgetAnalyser.Engine/Ledger/Data/DtoToLedgerBookMapper.cs
+++ b/BudgetAnalyser.Engine/Ledger/Data/DtoToLedgerBookMapper.cs
@@ -6,6 +6,10 @@ using BudgetAnalyser.Engine.Annotations;
 
 namespace BudgetAnalyser.Engine.Ledger.Data
 {
+    /// <summary>
+    /// An overriden mapper class to allow custom initialisation to be done after the base <see cref="LedgerBook"/> has been created and mapped.
+    /// For example: Must make sure that the <see cref="LedgerBook.Ledgers"/> Collection is populated and each one has a default storage Account.
+    /// </summary>
     [AutoRegisterWithIoC(SingleInstance = true, RegisterAs = typeof(BasicMapper<LedgerBookDto, LedgerBook>))]
     public class DtoToLedgerBookMapper : MagicMapper<LedgerBookDto, LedgerBook>
     {

--- a/BudgetAnalyser.Engine/Ledger/Data/LedgerAutoMapperConfiguration.cs
+++ b/BudgetAnalyser.Engine/Ledger/Data/LedgerAutoMapperConfiguration.cs
@@ -15,12 +15,14 @@ namespace BudgetAnalyser.Engine.Ledger.Data
         private readonly IBudgetBucketRepository bucketRepo;
         private readonly ILedgerTransactionFactory ledgerTransactionFactory;
         private readonly ILogger logger;
+        private readonly ILedgerBookFactory ledgerBookFactory;
 
         public LedgerAutoMapperConfiguration(
             [NotNull] ILedgerTransactionFactory ledgerTransactionFactory,
             [NotNull] IAccountTypeRepository accountTypeRepo,
             [NotNull] IBudgetBucketRepository bucketRepo,
-            [NotNull] ILogger logger)
+            [NotNull] ILogger logger,
+            [NotNull] ILedgerBookFactory ledgerBookFactory)
         {
             if (ledgerTransactionFactory == null)
             {
@@ -46,6 +48,7 @@ namespace BudgetAnalyser.Engine.Ledger.Data
             this.accountTypeRepo = accountTypeRepo;
             this.bucketRepo = bucketRepo;
             this.logger = logger;
+            this.ledgerBookFactory = ledgerBookFactory;
         }
 
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Simple Automapper expressions artificially inflating cyclomatic complexity")]
@@ -98,7 +101,6 @@ namespace BudgetAnalyser.Engine.Ledger.Data
                 .ForMember(entry => entry.Transactions, m => m.MapFrom(dto => dto.Transactions.OrderByDescending(t => t.TransactionType)));
 
             Mapper.CreateMap<LedgerEntryLineDto, LedgerEntryLine>()
-                .ConstructUsing((LedgerEntryLineDto x) => new LedgerEntryLine(this.logger))
                 .ForMember(line => line.IsNew, m => m.MapFrom(dto => false));
 
             Mapper.CreateMap<LedgerEntryLine, LedgerEntryLineDto>()
@@ -108,7 +110,7 @@ namespace BudgetAnalyser.Engine.Ledger.Data
                 .ForMember(dto => dto.Checksum, m => m.Ignore());
 
             Mapper.CreateMap<LedgerBookDto, LedgerBook>()
-                .ConstructUsing(new Func<LedgerBookDto, LedgerBook>(dto => new LedgerBook(this.logger)));
+                .ConstructUsing(new Func<LedgerBookDto, LedgerBook>(dto => this.ledgerBookFactory.CreateNew()));
 
             Mapper.CreateMap<ToDoTask, ToDoTaskDto>();
 

--- a/BudgetAnalyser.Engine/Ledger/ILedgerBookFactory.cs
+++ b/BudgetAnalyser.Engine/Ledger/ILedgerBookFactory.cs
@@ -1,0 +1,11 @@
+﻿namespace BudgetAnalyser.Engine.Ledger
+{
+    /// <summary>
+    ///     A factory to create new instances of a <see cref="LedgerBook" />.
+    ///     Used by persistence and when the user creates a new one.
+    /// </summary>
+    public interface ILedgerBookFactory
+    {
+        LedgerBook CreateNew();
+    }
+}

--- a/BudgetAnalyser.Engine/Ledger/IReconciliationBuilder.cs
+++ b/BudgetAnalyser.Engine/Ledger/IReconciliationBuilder.cs
@@ -21,6 +21,6 @@ namespace BudgetAnalyser.Engine.Ledger
         ///     Creates a new monthly reconciliation the the given <see cref="LedgerBook" /> for the current month.
         /// </summary>
         /// <returns>A newly created and populated <see cref="LedgerEntryLine" />.</returns>
-        LedgerEntryLine CreateNewMonthlyReconciliation(DateTime startDateIncl, IEnumerable<BankBalance> bankBalances, BudgetModel budget, StatementModel statement, ToDoCollection toDoList);
+        LedgerEntryLine CreateNewMonthlyReconciliation(DateTime reconciliationDateExcl, IEnumerable<BankBalance> bankBalances, BudgetModel budget, StatementModel statement, ToDoCollection toDoList);
     }
 }

--- a/BudgetAnalyser.Engine/Ledger/IReconciliationBuilder.cs
+++ b/BudgetAnalyser.Engine/Ledger/IReconciliationBuilder.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
+using BudgetAnalyser.Engine.Annotations;
 using BudgetAnalyser.Engine.Budget;
 using BudgetAnalyser.Engine.Statement;
 
 namespace BudgetAnalyser.Engine.Ledger
 {
     /// <summary>
-    /// Responsible for reconciliation the month's transactions against the budget and creating a <see cref="LedgerEntryLine"/> that shows the results.
+    ///     Responsible for reconciliation the month's transactions against the budget and creating a
+    ///     <see cref="LedgerEntryLine" /> that shows the results.
     /// </summary>
     public interface IReconciliationBuilder
     {
@@ -21,6 +23,11 @@ namespace BudgetAnalyser.Engine.Ledger
         ///     Creates a new monthly reconciliation the the given <see cref="LedgerBook" /> for the current month.
         /// </summary>
         /// <returns>A newly created and populated <see cref="LedgerEntryLine" />.</returns>
-        LedgerEntryLine CreateNewMonthlyReconciliation(DateTime reconciliationDateExcl, IEnumerable<BankBalance> bankBalances, BudgetModel budget, StatementModel statement, ToDoCollection toDoList);
+        LedgerEntryLine CreateNewMonthlyReconciliation(
+            DateTime reconciliationDateExcl,
+            [NotNull] IEnumerable<BankBalance> bankBalances,
+            [NotNull] BudgetModel budget,
+            [NotNull] StatementModel statement,
+            [NotNull] ToDoCollection toDoList);
     }
 }

--- a/BudgetAnalyser.Engine/Ledger/IReconciliationBuilder.cs
+++ b/BudgetAnalyser.Engine/Ledger/IReconciliationBuilder.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using BudgetAnalyser.Engine.Budget;
+using BudgetAnalyser.Engine.Statement;
+
+namespace BudgetAnalyser.Engine.Ledger
+{
+    /// <summary>
+    /// Responsible for reconciliation the month's transactions against the budget and creating a <see cref="LedgerEntryLine"/> that shows the results.
+    /// </summary>
+    public interface IReconciliationBuilder
+    {
+        /// <summary>
+        ///     The <see cref="LedgerBook" /> that we are building a monthly reconciliation for. This property must be set prior to
+        ///     calling <see cref="CreateNewMonthlyReconciliation" /> otherwise a
+        ///     <see cref="ArgumentException" /> will be thrown.
+        /// </summary>
+        LedgerBook LedgerBook { get; set; }
+
+        /// <summary>
+        ///     Creates a new monthly reconciliation the the given <see cref="LedgerBook" /> for the current month.
+        /// </summary>
+        /// <returns>A newly created and populated <see cref="LedgerEntryLine" />.</returns>
+        LedgerEntryLine CreateNewMonthlyReconciliation(DateTime startDateIncl, IEnumerable<BankBalance> bankBalances, BudgetModel budget, StatementModel statement, ToDoCollection toDoList);
+    }
+}

--- a/BudgetAnalyser.Engine/Ledger/IReconciliationConsistency.cs
+++ b/BudgetAnalyser.Engine/Ledger/IReconciliationConsistency.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace BudgetAnalyser.Engine.Ledger
+{
+    public interface IReconciliationConsistency
+    {
+        IDisposable EnsureConsistency(LedgerBook book);
+    }
+}

--- a/BudgetAnalyser.Engine/Ledger/LedgerBook.cs
+++ b/BudgetAnalyser.Engine/Ledger/LedgerBook.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -13,14 +12,14 @@ namespace BudgetAnalyser.Engine.Ledger
     public class LedgerBook : IModelValidate
     {
         private readonly IReconciliationBuilder reconciliationBuilder;
-        private readonly ILogger logger;
         private List<LedgerBucket> ledgersColumns = new List<LedgerBucket>();
         private List<LedgerEntryLine> reconciliations;
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="LedgerBook"/> class.  The Persistence system calls this constructor, not the IoC system. 
+        ///     Constructs a new instance of the <see cref="LedgerBook" /> class.  The Persistence system calls this constructor,
+        ///     not the IoC system.
         /// </summary>
-        public LedgerBook(ILogger logger, [NotNull] IReconciliationBuilder reconciliationBuilder)
+        public LedgerBook([NotNull] IReconciliationBuilder reconciliationBuilder)
         {
             if (reconciliationBuilder == null)
             {
@@ -28,7 +27,6 @@ namespace BudgetAnalyser.Engine.Ledger
             }
             this.reconciliationBuilder = reconciliationBuilder;
             this.reconciliationBuilder.LedgerBook = this;
-            this.logger = logger ?? new NullLogger();
             this.reconciliations = new List<LedgerEntryLine>();
         }
 
@@ -103,8 +101,10 @@ namespace BudgetAnalyser.Engine.Ledger
         ///     Creates a new LedgerEntryLine for this <see cref="LedgerBook" />.
         /// </summary>
         /// <param name="reconciliationDate">
-        ///     The startDate for the <see cref="LedgerEntryLine" />. This is usually the previous Month's "Reconciliation-Date", as this month's reconciliation starts with this date and includes transactions
-        ///     from that date. This date is different to the "Reconciliation-Date" that appears next to the resulting reconciliation which is the end date for the period.
+        ///     The startDate for the <see cref="LedgerEntryLine" />. This is usually the previous Month's "Reconciliation-Date",
+        ///     as this month's reconciliation starts with this date and includes transactions
+        ///     from that date. This date is different to the "Reconciliation-Date" that appears next to the resulting
+        ///     reconciliation which is the end date for the period.
         /// </param>
         /// <param name="currentBankBalances">
         ///     The bank balances as at the reconciliation date to include in this new single line of the
@@ -121,10 +121,10 @@ namespace BudgetAnalyser.Engine.Ledger
             DateTime reconciliationDate,
             IEnumerable<BankBalance> currentBankBalances,
             BudgetModel budget,
-            ToDoCollection toDoList = null,
-            StatementModel statement = null)
+            ToDoCollection toDoList,
+            StatementModel statement)
         {
-            var newLine = this.reconciliationBuilder.CreateNewMonthlyReconciliation(reconciliationDate, currentBankBalances, budget, statement, toDoList);
+            LedgerEntryLine newLine = this.reconciliationBuilder.CreateNewMonthlyReconciliation(reconciliationDate, currentBankBalances, budget, statement, toDoList);
             this.reconciliations.Insert(0, newLine);
             return newLine;
         }

--- a/BudgetAnalyser.Engine/Ledger/LedgerBook.cs
+++ b/BudgetAnalyser.Engine/Ledger/LedgerBook.cs
@@ -118,7 +118,7 @@ namespace BudgetAnalyser.Engine.Ledger
         /// <param name="statement">The currently loaded statement.</param>
         /// <param name="ignoreWarnings">Ignores validation warnings if true, otherwise <see cref="ValidationWarningException" />.</param>
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="LedgerBook" /> is in an invalid state.</exception>
-        internal LedgerEntryLine Reconcile(
+        internal virtual LedgerEntryLine Reconcile(
             DateTime reconciliationStartDate,
             IEnumerable<BankBalance> currentBankBalances,
             BudgetModel budget,

--- a/BudgetAnalyser.Engine/Ledger/LedgerBookFactory.cs
+++ b/BudgetAnalyser.Engine/Ledger/LedgerBookFactory.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using BudgetAnalyser.Engine.Annotations;
+
+namespace BudgetAnalyser.Engine.Ledger
+{
+    [AutoRegisterWithIoC]
+    internal class LedgerBookFactory : ILedgerBookFactory
+    {
+        private readonly IReconciliationBuilder reconciliationBuilder;
+        private readonly ILogger logger;
+
+        public LedgerBookFactory([NotNull] IReconciliationBuilder reconciliationBuilder, [NotNull] ILogger logger)
+        {
+            if (reconciliationBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(reconciliationBuilder));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            this.reconciliationBuilder = reconciliationBuilder;
+            this.logger = logger;
+        }
+
+        public LedgerBook CreateNew()
+        {
+            return new LedgerBook(this.logger, this.reconciliationBuilder);
+        }
+    }
+}

--- a/BudgetAnalyser.Engine/Ledger/LedgerBookFactory.cs
+++ b/BudgetAnalyser.Engine/Ledger/LedgerBookFactory.cs
@@ -27,7 +27,7 @@ namespace BudgetAnalyser.Engine.Ledger
 
         public LedgerBook CreateNew()
         {
-            return new LedgerBook(this.logger, this.reconciliationBuilder);
+            return new LedgerBook(this.reconciliationBuilder);
         }
     }
 }

--- a/BudgetAnalyser.Engine/Ledger/LedgerEntryLine.cs
+++ b/BudgetAnalyser.Engine/Ledger/LedgerEntryLine.cs
@@ -35,9 +35,9 @@ namespace BudgetAnalyser.Engine.Ledger
         ///     Constructs a new instance of <see cref="LedgerEntryLine" />.
         ///     Use this constructor for adding a new line when reconciling once a month.
         /// </summary>
-        /// <param name="date">The date of the line</param>
+        /// <param name="reconciliationDate">The date of the line</param>
         /// <param name="bankBalances">The bank balances for this date.</param>
-        internal LedgerEntryLine(DateTime date, [NotNull] IEnumerable<BankBalance> bankBalances)
+        internal LedgerEntryLine(DateTime reconciliationDate, [NotNull] IEnumerable<BankBalance> bankBalances)
             : this()
         {
             if (bankBalances == null)
@@ -45,7 +45,7 @@ namespace BudgetAnalyser.Engine.Ledger
                 throw new ArgumentNullException(nameof(bankBalances));
             }
 
-            Date = date;
+            Date = reconciliationDate;
             this.bankBalancesList = bankBalances.ToList();
         }
 

--- a/BudgetAnalyser.Engine/Ledger/LedgerEntryLine.cs
+++ b/BudgetAnalyser.Engine/Ledger/LedgerEntryLine.cs
@@ -3,11 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using BudgetAnalyser.Engine.Account;
 using BudgetAnalyser.Engine.Annotations;
-using BudgetAnalyser.Engine.Budget;
-using BudgetAnalyser.Engine.Statement;
 
 namespace BudgetAnalyser.Engine.Ledger
 {
@@ -20,9 +16,6 @@ namespace BudgetAnalyser.Engine.Ledger
     /// </summary>
     public class LedgerEntryLine
     {
-        public const string MatchedPrefix = "Matched ";
-        private static readonly string[] DisallowedChars = { "\\", "{", "}", "[", "]", "^", "=" };
-        private readonly ILogger logger;
         private List<BankBalanceAdjustmentTransaction> bankBalanceAdjustments = new List<BankBalanceAdjustmentTransaction>();
         private List<BankBalance> bankBalancesList;
         private List<LedgerEntry> entries = new List<LedgerEntry>();
@@ -33,15 +26,8 @@ namespace BudgetAnalyser.Engine.Ledger
         ///     implicitly using the
         ///     private and internal setters.
         /// </summary>
-        /// <param name="logger">The diagnostics logger</param>
-        internal LedgerEntryLine([NotNull] ILogger logger)
+        internal LedgerEntryLine()
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            this.logger = logger;
             IsNew = true;
         }
 
@@ -51,9 +37,8 @@ namespace BudgetAnalyser.Engine.Ledger
         /// </summary>
         /// <param name="date">The date of the line</param>
         /// <param name="bankBalances">The bank balances for this date.</param>
-        /// <param name="logger">The diagnostics logger</param>
-        internal LedgerEntryLine(DateTime date, [NotNull] IEnumerable<BankBalance> bankBalances, [NotNull] ILogger logger)
-            : this(logger)
+        internal LedgerEntryLine(DateTime date, [NotNull] IEnumerable<BankBalance> bankBalances)
+            : this()
         {
             if (bankBalances == null)
             {
@@ -106,7 +91,7 @@ namespace BudgetAnalyser.Engine.Ledger
         public IEnumerable<LedgerEntry> Entries
         {
             get { return this.entries; }
-            [UsedImplicitly] private set { this.entries = value.ToList(); }
+            private set { this.entries = value.ToList(); }
         }
 
         /// <summary>
@@ -148,92 +133,6 @@ namespace BudgetAnalyser.Engine.Ledger
         /// </summary>
         internal bool IsNew { get; private set; }
 
-        internal static IEnumerable<Transaction> TransactionsToAutoMatch(IEnumerable<Transaction> transactions, string autoMatchingReference)
-        {
-            IOrderedEnumerable<Transaction> txns = transactions.Where(
-                t =>
-                    t.Reference1.TrimEndSafely() == autoMatchingReference
-                    || t.Reference2.TrimEndSafely() == autoMatchingReference
-                    || t.Reference3.TrimEndSafely() == autoMatchingReference)
-                .OrderBy(t => t.Amount);
-            return txns;
-        }
-
-        /// <summary>
-        ///     Called by <see cref="LedgerBook.Reconcile" />. It builds the contents of the new ledger line based on budget and
-        ///     statement input.
-        /// </summary>
-        /// <param name="parentLedgerBook">
-        ///     The parent Ledger Book.  Used to extract information from previous <see cref="LedgerEntry" />s to construct the
-        ///     running
-        ///     balance for the entries this line contains. Also used to get the LedgerBucket instance for the new Ledger Entries.
-        ///     This is intentionally not necessarily the same as the previous Ledger Entry from last month, to allow the ledger to
-        ///     be
-        ///     transfered to a different bank account.
-        /// </param>
-        /// <param name="currentBudget">The current applicable budget</param>
-        /// <param name="statement">The current period statement.</param>
-        /// <param name="startDateIncl">
-        ///     The date of the previous ledger line. This is used to include transactions from the
-        ///     Statement up to but excluding the date of this reconciliation.
-        /// </param>
-        /// <param name="toDoList">
-        ///     The task list that will have tasks added to it to remind the user to perform transfers and
-        ///     payments etc.
-        /// </param>
-        internal void AddNew(
-            LedgerBook parentLedgerBook,
-            BudgetModel currentBudget,
-            StatementModel statement,
-            DateTime startDateIncl,
-            ToDoCollection toDoList)
-        {
-            if (!IsNew)
-            {
-                throw new InvalidOperationException("Cannot add a new entry to an existing Ledger Line, only new Ledger Lines can have new entries added.");
-            }
-
-            DateTime reconciliationDate = Date;
-            // Date filter must include the start date, which goes back to and includes the previous ledger date up to the date of this ledger line, but excludes this ledger date.
-            // For example if this is a reconciliation for the 20/Feb then the start date is 20/Jan and the finish date is 20/Feb. So transactions pulled from statement are between
-            // 20/Jan (inclusive) and 19/Feb (inclusive).
-            List<Transaction> filteredStatementTransactions = statement?.AllTransactions.Where(t => t.Date >= startDateIncl && t.Date < reconciliationDate).ToList()
-                                                              ?? new List<Transaction>();
-
-            IEnumerable<LedgerEntry> previousLedgerBalances = CompileLedgersAndBalances(parentLedgerBook);
-
-            foreach (LedgerEntry previousLedgerEntry in previousLedgerBalances)
-            {
-                LedgerBucket ledgerBucket;
-                decimal openingBalance = previousLedgerEntry.Balance;
-                LedgerBucket bookLedgerDefaults = parentLedgerBook.Ledgers.Single(l => l.BudgetBucket == previousLedgerEntry.LedgerBucket.BudgetBucket);
-                if (previousLedgerEntry.LedgerBucket.StoredInAccount != bookLedgerDefaults.StoredInAccount)
-                {
-                    // Check to see if a ledger has been moved into a new default account since last reconciliation.
-                    ledgerBucket = bookLedgerDefaults;
-                }
-                else
-                {
-                    ledgerBucket = previousLedgerEntry.LedgerBucket;
-                }
-
-                var newEntry = new LedgerEntry(true) { Balance = openingBalance, LedgerBucket = ledgerBucket };
-                List<LedgerTransaction> transactions = IncludeBudgetedAmount(currentBudget, ledgerBucket, reconciliationDate, toDoList);
-                transactions.AddRange(IncludeStatementTransactions(newEntry, filteredStatementTransactions));
-                AutoMatchTransactionsAlreadyInPreviousPeriod(filteredStatementTransactions, previousLedgerEntry, transactions, toDoList);
-                newEntry.SetTransactionsForReconciliation(transactions, reconciliationDate);
-
-                this.entries.Add(newEntry);
-            }
-
-            CreateBalanceAdjustmentTasksIfRequired(toDoList);
-            if (statement != null)
-            {
-                AddBalanceAdjustmentsForFutureTransactions(statement, reconciliationDate, toDoList);
-            }
-            CreateTasksToJournalFundsIfPaidFromDifferentAccount(filteredStatementTransactions, toDoList);
-        }
-
         internal BankBalanceAdjustmentTransaction BalanceAdjustment(decimal adjustment, string narrative)
         {
             if (!IsNew)
@@ -264,6 +163,14 @@ namespace BudgetAnalyser.Engine.Ledger
             {
                 this.bankBalanceAdjustments.Remove(txn);
             }
+        }
+
+        /// <summary>
+        /// Sets the <see cref="LedgerEntry"/> list for this reconciliation. Used when building a new reconciliation and populating a new <see cref="LedgerEntryLine"/>.
+        /// </summary>
+        internal void SetNewLedgerEntries(IEnumerable<LedgerEntry> ledgerEntries)
+        {
+            Entries = ledgerEntries.ToList();
         }
 
         internal void Unlock()
@@ -320,51 +227,6 @@ namespace BudgetAnalyser.Engine.Ledger
             return result;
         }
 
-        private static IEnumerable<LedgerEntry> CompileLedgersAndBalances(LedgerBook parentLedgerBook)
-        {
-            var ledgersAndBalances = new List<LedgerEntry>();
-            LedgerEntryLine previousLine = parentLedgerBook.Reconciliations.FirstOrDefault();
-            if (previousLine == null)
-            {
-                return parentLedgerBook.Ledgers.Select(ledger => new LedgerEntry { Balance = 0, LedgerBucket = ledger });
-            }
-
-            foreach (LedgerBucket ledger in parentLedgerBook.Ledgers)
-            {
-                // Ledger Columns from a previous are not necessarily equal if the StoredInAccount has changed.
-                LedgerEntry previousEntry = previousLine.Entries.FirstOrDefault(e => e.LedgerBucket.BudgetBucket == ledger.BudgetBucket);
-
-                // Its important to use the ledger column value from the book level map, not from the previous entry. The user
-                // could have moved the ledger to a different account and so, the ledger column value in the book level map will be different.
-                if (previousEntry == null)
-                {
-                    // Indicates a new ledger column has been added to the book starting this month.
-                    ledgersAndBalances.Add(new LedgerEntry { Balance = 0, LedgerBucket = ledger });
-                }
-                else
-                {
-                    ledgersAndBalances.Add(previousEntry);
-                }
-            }
-
-            return ledgersAndBalances;
-        }
-
-        private static string ExtractNarrative(Transaction t)
-        {
-            if (!string.IsNullOrWhiteSpace(t.Description))
-            {
-                return t.Description;
-            }
-
-            if (t.TransactionType != null)
-            {
-                return t.TransactionType.ToString();
-            }
-
-            return string.Empty;
-        }
-
         private static decimal FindPreviousEntryOpeningBalance([CanBeNull] LedgerEntryLine previousLine, [NotNull] LedgerBucket ledgerBucket)
         {
             if (ledgerBucket == null)
@@ -379,253 +241,6 @@ namespace BudgetAnalyser.Engine.Ledger
 
             LedgerEntry previousEntry = previousLine.Entries.FirstOrDefault(e => e.LedgerBucket.BudgetBucket == ledgerBucket.BudgetBucket);
             return previousEntry?.Balance ?? 0;
-        }
-
-        private static IEnumerable<LedgerTransaction> IncludeStatementTransactions(LedgerEntry newEntry, ICollection<Transaction> filteredStatementTransactions)
-        {
-            if (filteredStatementTransactions.None())
-            {
-                return new List<LedgerTransaction>();
-            }
-
-            List<Transaction> transactions = filteredStatementTransactions.Where(t => t.BudgetBucket == newEntry.LedgerBucket.BudgetBucket).ToList();
-            if (transactions.Any())
-            {
-                IEnumerable<LedgerTransaction> newLedgerTransactions = transactions.Select<Transaction, LedgerTransaction>(
-                    t =>
-                    {
-                        if (t.Amount < 0)
-                        {
-                            return new CreditLedgerTransaction(t.Id)
-                            {
-                                Amount = t.Amount,
-                                Narrative = ExtractNarrative(t),
-                                Date = t.Date
-                            };
-                        }
-
-                        return new CreditLedgerTransaction(t.Id)
-                        {
-                            Amount = t.Amount,
-                            Narrative = ExtractNarrative(t),
-                            Date = t.Date
-                        };
-                    });
-
-                return newLedgerTransactions.ToList();
-            }
-
-            return new List<LedgerTransaction>();
-        }
-
-        private static string IssueTransactionReferenceNumber()
-        {
-            var reference = new StringBuilder(Convert.ToBase64String(Guid.NewGuid().ToByteArray()));
-            foreach (string disallowedChar in DisallowedChars)
-            {
-                reference.Replace(disallowedChar, string.Empty);
-            }
-
-            return reference.ToString().Substring(0, 7);
-        }
-
-        private void AddBalanceAdjustmentsForFutureTransactions(StatementModel statement, DateTime reconciliationDate, ToDoCollection toDoList)
-        {
-            var adjustmentsMade = false;
-            foreach (Transaction futureTransaction in statement.AllTransactions
-                .Where(t => t.Account.AccountType != AccountType.CreditCard && t.Date >= reconciliationDate && !(t.BudgetBucket is JournalBucket)))
-            {
-                adjustmentsMade = true;
-                BalanceAdjustment(-futureTransaction.Amount, "Remove future transaction for " + futureTransaction.Date.ToShortDateString())
-                    .WithAccount(futureTransaction.Account);
-            }
-
-            if (adjustmentsMade)
-            {
-                toDoList.Add(new ToDoTask("Check auto-generated balance adjustments for future transactions.", true));
-            }
-        }
-
-        private void AutoMatchTransactionsAlreadyInPreviousPeriod(
-            List<Transaction> transactions,
-            LedgerEntry previousLedgerEntry,
-            List<LedgerTransaction> newLedgerTransactions,
-            ToDoCollection toDoList)
-        {
-            List<LedgerTransaction> ledgerAutoMatchTransactions = previousLedgerEntry.Transactions.Where(t => !string.IsNullOrWhiteSpace(t.AutoMatchingReference)).ToList();
-            var checkMatchedTxns = new List<LedgerTransaction>();
-            var checkMatchCount = 0;
-            foreach (LedgerTransaction lastMonthLedgerTransaction in ledgerAutoMatchTransactions)
-            {
-                this.logger.LogInfo(
-                    l =>
-                        l.Format(
-                            "Ledger Reconciliation - AutoMatching - Found {0} {1} ledger transaction that require matching.",
-                            ledgerAutoMatchTransactions.Count(),
-                            previousLedgerEntry.LedgerBucket.BudgetBucket.Code));
-                LedgerTransaction ledgerTxn = lastMonthLedgerTransaction;
-                foreach (Transaction matchingStatementTransaction in TransactionsToAutoMatch(transactions, lastMonthLedgerTransaction.AutoMatchingReference))
-                {
-                    this.logger.LogInfo(l => l.Format("Ledger Reconciliation - AutoMatching - Matched {0} ==> {1}", ledgerTxn, matchingStatementTransaction));
-                    ledgerTxn.Id = matchingStatementTransaction.Id;
-                    if (!ledgerTxn.AutoMatchingReference.StartsWith(MatchedPrefix, StringComparison.Ordinal))
-                    {
-                        // There will be two statement transactions but only one ledger transaction to match to.
-                        checkMatchCount++;
-                        ledgerTxn.AutoMatchingReference = string.Format(CultureInfo.InvariantCulture, "{0}{1}", MatchedPrefix, ledgerTxn.AutoMatchingReference);
-                        checkMatchedTxns.Add(ledgerTxn);
-                    }
-
-                    LedgerTransaction duplicateTransaction = newLedgerTransactions.FirstOrDefault(t => t.Id == matchingStatementTransaction.Id);
-                    if (duplicateTransaction != null)
-                    {
-                        this.logger.LogInfo(l => l.Format("Ledger Reconciliation - Removing Duplicate Ledger transaction after auto-matching: {0}", duplicateTransaction));
-                        newLedgerTransactions.Remove(duplicateTransaction);
-                    }
-                }
-            }
-
-            if (ledgerAutoMatchTransactions.Any() && ledgerAutoMatchTransactions.Count() != checkMatchCount)
-            {
-                this.logger.LogWarning(
-                    l =>
-                        l.Format(
-                            "Ledger Reconciliation - WARNING {0} ledger transactions appear to be waiting to be automatched, but not statement transactions were found. {1}",
-                            ledgerAutoMatchTransactions.Count(),
-                            ledgerAutoMatchTransactions.First().AutoMatchingReference));
-                IEnumerable<LedgerTransaction> unmatchedTxns = ledgerAutoMatchTransactions.Except(checkMatchedTxns);
-                foreach (LedgerTransaction txn in unmatchedTxns)
-                {
-                    toDoList.Add(
-                        new ToDoTask(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                "WARNING: Missing auto-match transaction. Transfer {0:C} with reference {1} Dated {2:d} to {3}. See log for more details.",
-                                txn.Amount,
-                                txn.AutoMatchingReference,
-                                Date.AddDays(-1),
-                                previousLedgerEntry.LedgerBucket.StoredInAccount),
-                            true));
-                }
-            }
-        }
-
-        private void CreateBalanceAdjustmentTasksIfRequired(ToDoCollection toDoList)
-        {
-            List<TransferTask> transferTasks = toDoList.OfType<TransferTask>().ToList();
-            foreach (IGrouping<Account.Account, TransferTask> grouping in transferTasks.GroupBy(t => t.SourceAccount, tasks => tasks))
-            {
-                // Rather than create a task, just do it
-                BalanceAdjustment(
-                    -grouping.Sum(t => t.Amount),
-                    "Adjustment for moving budgeted amounts from income account. ")
-                    .WithAccount(grouping.Key);
-                //var balanceAdjustmentTask = new ToDoTask(
-                //    string.Format(
-                //        CultureInfo.CurrentCulture,
-                //        "Add new balance adjustment for {0} Account with the amount of {1:C}. (This is the total transfers of budgeted amounts from this account).",
-                //        grouping.Key,
-                //        -grouping.Sum(t => t.Amount)),
-                //    true);
-                //toDoList.Add(balanceAdjustmentTask);
-            }
-
-            foreach (IGrouping<Account.Account, TransferTask> grouping in transferTasks.GroupBy(t => t.DestinationAccount, tasks => tasks))
-            {
-                // Rather than create a task, just do it
-                BalanceAdjustment(
-                    grouping.Sum(t => t.Amount),
-                    "Adjustment for moving budgeted amounts to destination account. ")
-                    .WithAccount(grouping.Key);
-                //var balanceAdjustmentTask = new ToDoTask(
-                //    string.Format(
-                //        CultureInfo.CurrentCulture,
-                //        "Add new balance adjustment for {0} Account with the amount of {1:C}. (This is the total transfers of budgeted amounts into this account).",
-                //        grouping.Key,
-                //        grouping.Sum(t => t.Amount)),
-                //    true);
-                //toDoList.Add(balanceAdjustmentTask);
-            }
-        }
-
-        private void CreateTasksToJournalFundsIfPaidFromDifferentAccount(IEnumerable<Transaction> transactions, ToDoCollection toDoList)
-        {
-            var syncRoot = new object();
-            Dictionary<BudgetBucket, Account.Account> ledgerBuckets = Entries.Select(e => e.LedgerBucket).Distinct().ToDictionary(l => l.BudgetBucket, l => l.StoredInAccount);
-
-            // Amount < 0: This is because we are only interested in looking for debit transactions against a different account. These transactions will need to be journaled from the stored-in account.
-            Parallel.ForEach(
-                transactions.Where(t => t.Amount < 0 && t.Account.AccountType != AccountType.CreditCard).ToList(),
-                t =>
-                {
-                    if (!ledgerBuckets.ContainsKey(t.BudgetBucket))
-                    {
-                        return;
-                    }
-                    Account.Account ledgerAccount = ledgerBuckets[t.BudgetBucket];
-                    if (t.Account != ledgerAccount)
-                    {
-                        lock (syncRoot)
-                        {
-                            toDoList.Add(
-                                new TransferTask(
-                                    $"A {t.BudgetBucket.Code} payment for {t.Amount:C} has been made from {t.Account}, but funds are stored in {ledgerAccount}.",
-                                    true)
-                                {
-                                    Amount = t.Amount,
-                                    SourceAccount = ledgerAccount,
-                                    DestinationAccount = t.Account
-                                });
-                        }
-                    }
-                });
-        }
-
-        private List<LedgerTransaction> IncludeBudgetedAmount(BudgetModel currentBudget, LedgerBucket ledgerBucket, DateTime reconciliationDate, ToDoCollection toDoList)
-        {
-            Expense budgetedExpense = currentBudget.Expenses.FirstOrDefault(e => e.Bucket.Code == ledgerBucket.BudgetBucket.Code);
-            var transactions = new List<LedgerTransaction>();
-            if (budgetedExpense != null)
-            {
-                BudgetCreditLedgerTransaction budgetedAmount;
-                if (ledgerBucket.StoredInAccount.IsSalaryAccount)
-                {
-                    budgetedAmount = new BudgetCreditLedgerTransaction
-                    {
-                        Amount = budgetedExpense.Bucket.Active ? budgetedExpense.Amount : 0,
-                        Narrative = budgetedExpense.Bucket.Active ? "Budgeted Amount" : "Warning! Bucket has been disabled."
-                    };
-                }
-                else
-                {
-                    budgetedAmount = new BudgetCreditLedgerTransaction
-                    {
-                        Amount = budgetedExpense.Bucket.Active ? budgetedExpense.Amount : 0,
-                        Narrative =
-                            budgetedExpense.Bucket.Active
-                                ? "Budget amount must be transferred into this account with a bank transfer, use the reference number for the transfer."
-                                : "Warning! Bucket has been disabled.",
-                        AutoMatchingReference = IssueTransactionReferenceNumber()
-                    };
-                    // TODO Maybe the budget should know which account the incomes go into, perhaps mapped against each income?
-                    Account.Account salaryAccount = BankBalances.Single(b => b.Account.IsSalaryAccount).Account;
-                    toDoList.Add(
-                        new TransferTask(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                "For {0} transfer {1:C} from Salary Account to {2} with auto-matching reference: {3}",
-                                budgetedExpense.Bucket.Code,
-                                budgetedAmount.Amount,
-                                ledgerBucket.StoredInAccount,
-                                budgetedAmount.AutoMatchingReference),
-                            true) { Amount = budgetedAmount.Amount, SourceAccount = salaryAccount, DestinationAccount = ledgerBucket.StoredInAccount });
-                }
-
-                budgetedAmount.Date = reconciliationDate;
-                transactions.Add(budgetedAmount);
-            }
-
-            return transactions;
         }
 
         private decimal TotalBankBalanceAdjustmentForAccount(Account.Account account)

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
@@ -455,7 +455,8 @@ namespace BudgetAnalyser.Engine.Ledger
                             Amount = budgetedAmount.Amount,
                             SourceAccount = salaryAccount,
                             DestinationAccount = ledgerBucket.StoredInAccount,
-                            BucketCode = budgetedExpense.Bucket.Code
+                            BucketCode = budgetedExpense.Bucket.Code,
+                            Reference = budgetedAmount.AutoMatchingReference,
                         });
 
                 }

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
@@ -1,0 +1,472 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BudgetAnalyser.Engine.Account;
+using BudgetAnalyser.Engine.Annotations;
+using BudgetAnalyser.Engine.Budget;
+using BudgetAnalyser.Engine.Statement;
+
+namespace BudgetAnalyser.Engine.Ledger
+{
+    public interface IReconciliationBuilder
+    {
+        /// <summary>
+        ///     The <see cref="LedgerBook" /> that we are building a monthly reconciliation for. This property must be set prior to
+        ///     calling <see cref="CreateNewMonthlyReconciliation" /> otherwise a
+        ///     <see cref="ArgumentException" /> will be thrown.
+        /// </summary>
+        LedgerBook LedgerBook { get; set; }
+
+        /// <summary>
+        ///     Creates a new monthly reconciliation the the given <see cref="LedgerBook" /> for the current month.
+        /// </summary>
+        /// <returns>A newly created and populated <see cref="LedgerEntryLine" />.</returns>
+        LedgerEntryLine CreateNewMonthlyReconciliation(DateTime startDateIncl, IEnumerable<BankBalance> bankBalances, BudgetModel budget, StatementModel statement, ToDoCollection toDoList);
+    }
+
+
+    internal class ReconciliationBuilder : IReconciliationBuilder
+    {
+        internal const string MatchedPrefix = "Matched ";
+        private static readonly string[] DisallowedChars = { "\\", "{", "}", "[", "]", "^", "=" };
+        private readonly ILogger logger;
+        private LedgerEntryLine newReconciliationLine;
+
+        public ReconciliationBuilder([NotNull] ILogger logger)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            this.logger = logger;
+        }
+
+        public LedgerBook LedgerBook { get; set; }
+
+        public LedgerEntryLine CreateNewMonthlyReconciliation(DateTime startDateIncl, IEnumerable<BankBalance> bankBalances, BudgetModel budget, StatementModel statement, ToDoCollection toDoList)
+        {
+            if (LedgerBook == null)
+            {
+                throw new ArgumentException("The Ledger Book property cannot be null. You must set this prior to calling this method.");
+            }
+
+            try
+            {
+                this.newReconciliationLine = new LedgerEntryLine(startDateIncl, bankBalances);
+                AddNew(budget, statement, CalculateDateForReconcile(startDateIncl), toDoList);
+
+                CreateToDoForAnyOverdrawnSurplusBalance(toDoList);
+
+                return this.newReconciliationLine;
+            }
+            finally
+            {
+                this.newReconciliationLine = null;
+            }
+        }
+
+        internal static IEnumerable<Transaction> TransactionsToAutoMatch(IEnumerable<Transaction> transactions, string autoMatchingReference)
+        {
+            IOrderedEnumerable<Transaction> txns = transactions.Where(
+                t =>
+                    t.Reference1.TrimEndSafely() == autoMatchingReference
+                    || t.Reference2.TrimEndSafely() == autoMatchingReference
+                    || t.Reference3.TrimEndSafely() == autoMatchingReference)
+                .OrderBy(t => t.Amount);
+            return txns;
+        }
+
+        private static IEnumerable<LedgerEntry> CompileLedgersAndBalances(LedgerBook parentLedgerBook)
+        {
+            var ledgersAndBalances = new List<LedgerEntry>();
+            LedgerEntryLine previousLine = parentLedgerBook.Reconciliations.FirstOrDefault();
+            if (previousLine == null)
+            {
+                return parentLedgerBook.Ledgers.Select(ledger => new LedgerEntry { Balance = 0, LedgerBucket = ledger });
+            }
+
+            foreach (LedgerBucket ledger in parentLedgerBook.Ledgers)
+            {
+                // Ledger Columns from a previous are not necessarily equal if the StoredInAccount has changed.
+                LedgerEntry previousEntry = previousLine.Entries.FirstOrDefault(e => e.LedgerBucket.BudgetBucket == ledger.BudgetBucket);
+
+                // Its important to use the ledger column value from the book level map, not from the previous entry. The user
+                // could have moved the ledger to a different account and so, the ledger column value in the book level map will be different.
+                if (previousEntry == null)
+                {
+                    // Indicates a new ledger column has been added to the book starting this month.
+                    ledgersAndBalances.Add(new LedgerEntry { Balance = 0, LedgerBucket = ledger });
+                }
+                else
+                {
+                    ledgersAndBalances.Add(previousEntry);
+                }
+            }
+
+            return ledgersAndBalances;
+        }
+
+        private static string ExtractNarrative(Transaction t)
+        {
+            if (!string.IsNullOrWhiteSpace(t.Description))
+            {
+                return t.Description;
+            }
+
+            if (t.TransactionType != null)
+            {
+                return t.TransactionType.ToString();
+            }
+
+            return string.Empty;
+        }
+
+        private static IEnumerable<LedgerTransaction> IncludeStatementTransactions(LedgerEntry newEntry, ICollection<Transaction> filteredStatementTransactions)
+        {
+            if (filteredStatementTransactions.None())
+            {
+                return new List<LedgerTransaction>();
+            }
+
+            List<Transaction> transactions = filteredStatementTransactions.Where(t => t.BudgetBucket == newEntry.LedgerBucket.BudgetBucket).ToList();
+            if (transactions.Any())
+            {
+                IEnumerable<LedgerTransaction> newLedgerTransactions = transactions.Select<Transaction, LedgerTransaction>(
+                    t =>
+                    {
+                        if (t.Amount < 0)
+                        {
+                            return new CreditLedgerTransaction(t.Id)
+                            {
+                                Amount = t.Amount,
+                                Narrative = ExtractNarrative(t),
+                                Date = t.Date
+                            };
+                        }
+
+                        return new CreditLedgerTransaction(t.Id)
+                        {
+                            Amount = t.Amount,
+                            Narrative = ExtractNarrative(t),
+                            Date = t.Date
+                        };
+                    });
+
+                return newLedgerTransactions.ToList();
+            }
+
+            return new List<LedgerTransaction>();
+        }
+
+        private static string IssueTransactionReferenceNumber()
+        {
+            var reference = new StringBuilder(Convert.ToBase64String(Guid.NewGuid().ToByteArray()));
+            foreach (string disallowedChar in DisallowedChars)
+            {
+                reference.Replace(disallowedChar, string.Empty);
+            }
+
+            return reference.ToString().Substring(0, 7);
+        }
+
+        private void AddBalanceAdjustmentsForFutureTransactions(StatementModel statement, DateTime reconciliationDate, ToDoCollection toDoList)
+        {
+            var adjustmentsMade = false;
+            foreach (Transaction futureTransaction in statement.AllTransactions
+                .Where(t => t.Account.AccountType != AccountType.CreditCard && t.Date >= reconciliationDate && !(t.BudgetBucket is JournalBucket)))
+            {
+                adjustmentsMade = true;
+                this.newReconciliationLine.BalanceAdjustment(-futureTransaction.Amount, "Remove future transaction for " + futureTransaction.Date.ToShortDateString())
+                    .WithAccount(futureTransaction.Account);
+            }
+
+            if (adjustmentsMade)
+            {
+                toDoList.Add(new ToDoTask("Check auto-generated balance adjustments for future transactions.", true));
+            }
+        }
+
+        /// <summary>
+        ///     This is effectively stage 2 of the Reconciliation process.
+        ///     Called by <see cref="ReconciliationBuilder.CreateNewMonthlyReconciliation" />. It builds the contents of the new
+        ///     ledger line based on budget and
+        ///     statement input.
+        /// </summary>
+        /// <param name="budget">The current applicable budget</param>
+        /// <param name="statement">The current period statement.</param>
+        /// <param name="startDateIncl">
+        ///     The date of the previous ledger line. This is used to include transactions from the
+        ///     Statement starting from this date and including this date.
+        /// </param>
+        /// <param name="toDoList">
+        ///     The task list that will have tasks added to it to remind the user to perform transfers and
+        ///     payments etc.
+        /// </param>
+        private void AddNew(
+            BudgetModel budget,
+            StatementModel statement,
+            DateTime startDateIncl,
+            ToDoCollection toDoList)
+        {
+            if (!this.newReconciliationLine.IsNew)
+            {
+                throw new InvalidOperationException("Cannot add a new entry to an existing Ledger Line, only new Ledger Lines can have new entries added.");
+            }
+
+            DateTime reconciliationDate = this.newReconciliationLine.Date;
+            // Date filter must include the start date, which goes back to and includes the previous ledger date up to the date of this ledger line, but excludes this ledger date.
+            // For example if this is a reconciliation for the 20/Feb then the start date is 20/Jan and the finish date is 20/Feb. So transactions pulled from statement are between
+            // 20/Jan (inclusive) and 19/Feb (inclusive).
+            List<Transaction> filteredStatementTransactions = statement?.AllTransactions.Where(t => t.Date >= startDateIncl && t.Date < reconciliationDate).ToList()
+                                                              ?? new List<Transaction>();
+
+            IEnumerable<LedgerEntry> previousLedgerBalances = CompileLedgersAndBalances(LedgerBook);
+
+            var entries = new List<LedgerEntry>();
+            foreach (LedgerEntry previousLedgerEntry in previousLedgerBalances)
+            {
+                LedgerBucket ledgerBucket;
+                decimal openingBalance = previousLedgerEntry.Balance;
+                LedgerBucket bookLedgerDefaults = LedgerBook.Ledgers.Single(l => l.BudgetBucket == previousLedgerEntry.LedgerBucket.BudgetBucket);
+                if (previousLedgerEntry.LedgerBucket.StoredInAccount != bookLedgerDefaults.StoredInAccount)
+                {
+                    // Check to see if a ledger has been moved into a new default account since last reconciliation.
+                    ledgerBucket = bookLedgerDefaults;
+                }
+                else
+                {
+                    ledgerBucket = previousLedgerEntry.LedgerBucket;
+                }
+
+                var newEntry = new LedgerEntry(true) { Balance = openingBalance, LedgerBucket = ledgerBucket };
+                List<LedgerTransaction> transactions = IncludeBudgetedAmount(budget, ledgerBucket, reconciliationDate, toDoList);
+                transactions.AddRange(IncludeStatementTransactions(newEntry, filteredStatementTransactions));
+                AutoMatchTransactionsAlreadyInPreviousPeriod(filteredStatementTransactions, previousLedgerEntry, transactions, toDoList);
+                newEntry.SetTransactionsForReconciliation(transactions, reconciliationDate);
+
+                entries.Add(newEntry);
+            }
+
+            this.newReconciliationLine.SetNewLedgerEntries(entries);
+
+            CreateBalanceAdjustmentTasksIfRequired(toDoList);
+            if (statement != null)
+            {
+                AddBalanceAdjustmentsForFutureTransactions(statement, reconciliationDate, toDoList);
+            }
+
+            CreateTasksToJournalFundsIfPaidFromDifferentAccount(filteredStatementTransactions, toDoList);
+        }
+
+        private void AutoMatchTransactionsAlreadyInPreviousPeriod(
+            List<Transaction> transactions,
+            LedgerEntry previousLedgerEntry,
+            List<LedgerTransaction> newLedgerTransactions,
+            ToDoCollection toDoList)
+        {
+            List<LedgerTransaction> ledgerAutoMatchTransactions = previousLedgerEntry.Transactions.Where(t => !string.IsNullOrWhiteSpace(t.AutoMatchingReference)).ToList();
+            var checkMatchedTxns = new List<LedgerTransaction>();
+            var checkMatchCount = 0;
+            foreach (LedgerTransaction lastMonthLedgerTransaction in ledgerAutoMatchTransactions)
+            {
+                this.logger.LogInfo(
+                    l =>
+                        l.Format(
+                            "Ledger Reconciliation - AutoMatching - Found {0} {1} ledger transaction that require matching.",
+                            ledgerAutoMatchTransactions.Count(),
+                            previousLedgerEntry.LedgerBucket.BudgetBucket.Code));
+                LedgerTransaction ledgerTxn = lastMonthLedgerTransaction;
+                foreach (Transaction matchingStatementTransaction in TransactionsToAutoMatch(transactions, lastMonthLedgerTransaction.AutoMatchingReference))
+                {
+                    this.logger.LogInfo(l => l.Format("Ledger Reconciliation - AutoMatching - Matched {0} ==> {1}", ledgerTxn, matchingStatementTransaction));
+                    ledgerTxn.Id = matchingStatementTransaction.Id;
+                    if (!ledgerTxn.AutoMatchingReference.StartsWith(MatchedPrefix, StringComparison.Ordinal))
+                    {
+                        // There will be two statement transactions but only one ledger transaction to match to.
+                        checkMatchCount++;
+                        ledgerTxn.AutoMatchingReference = string.Format(CultureInfo.InvariantCulture, "{0}{1}", MatchedPrefix, ledgerTxn.AutoMatchingReference);
+                        checkMatchedTxns.Add(ledgerTxn);
+                    }
+
+                    LedgerTransaction duplicateTransaction = newLedgerTransactions.FirstOrDefault(t => t.Id == matchingStatementTransaction.Id);
+                    if (duplicateTransaction != null)
+                    {
+                        this.logger.LogInfo(l => l.Format("Ledger Reconciliation - Removing Duplicate Ledger transaction after auto-matching: {0}", duplicateTransaction));
+                        newLedgerTransactions.Remove(duplicateTransaction);
+                    }
+                }
+            }
+
+            if (ledgerAutoMatchTransactions.Any() && ledgerAutoMatchTransactions.Count() != checkMatchCount)
+            {
+                this.logger.LogWarning(
+                    l =>
+                        l.Format(
+                            "Ledger Reconciliation - WARNING {0} ledger transactions appear to be waiting to be automatched, but not statement transactions were found. {1}",
+                            ledgerAutoMatchTransactions.Count(),
+                            ledgerAutoMatchTransactions.First().AutoMatchingReference));
+                IEnumerable<LedgerTransaction> unmatchedTxns = ledgerAutoMatchTransactions.Except(checkMatchedTxns);
+                foreach (LedgerTransaction txn in unmatchedTxns)
+                {
+                    toDoList.Add(
+                        new ToDoTask(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                "WARNING: Missing auto-match transaction. Transfer {0:C} with reference {1} Dated {2:d} to {3}. See log for more details.",
+                                txn.Amount,
+                                txn.AutoMatchingReference,
+                                this.newReconciliationLine.Date.AddDays(-1),
+                                previousLedgerEntry.LedgerBucket.StoredInAccount),
+                            true));
+                }
+            }
+        }
+
+        /// <summary>
+        ///     When creating a new reconciliation a start startDate is required to be able to search a statement for transactions
+        ///     between a start startDate and
+        ///     the startDate specified (today or pay day). The start startDate should start from the previous ledger entry line or
+        ///     one month
+        ///     prior if no records
+        ///     exist.
+        /// </summary>
+        /// <param name="date">The chosen startDate from the user</param>
+        private DateTime CalculateDateForReconcile(DateTime date)
+        {
+            if (LedgerBook.Reconciliations.Any())
+            {
+                return LedgerBook.Reconciliations.First().Date;
+            }
+            DateTime startDateIncl = date.AddMonths(-1);
+            return startDateIncl;
+        }
+
+        private void CreateBalanceAdjustmentTasksIfRequired(ToDoCollection toDoList)
+        {
+            List<TransferTask> transferTasks = toDoList.OfType<TransferTask>().ToList();
+            foreach (IGrouping<Account.Account, TransferTask> grouping in transferTasks.GroupBy(t => t.SourceAccount, tasks => tasks))
+            {
+                // Rather than create a task, just do it
+                this.newReconciliationLine.BalanceAdjustment(
+                    -grouping.Sum(t => t.Amount),
+                    "Adjustment for moving budgeted amounts from income account. ")
+                    .WithAccount(grouping.Key);
+            }
+
+            foreach (IGrouping<Account.Account, TransferTask> grouping in transferTasks.GroupBy(t => t.DestinationAccount, tasks => tasks))
+            {
+                // Rather than create a task, just do it
+                this.newReconciliationLine.BalanceAdjustment(
+                    grouping.Sum(t => t.Amount),
+                    "Adjustment for moving budgeted amounts to destination account. ")
+                    .WithAccount(grouping.Key);
+            }
+        }
+
+        private void CreateTasksToJournalFundsIfPaidFromDifferentAccount(IEnumerable<Transaction> transactions, ToDoCollection toDoList)
+        {
+            var syncRoot = new object();
+            Dictionary<BudgetBucket, Account.Account> ledgerBuckets = this.newReconciliationLine.Entries.Select(e => e.LedgerBucket)
+                .Distinct()
+                .ToDictionary(l => l.BudgetBucket, l => l.StoredInAccount);
+
+            // Amount < 0: This is because we are only interested in looking for debit transactions against a different account. These transactions will need to be journaled from the stored-in account.
+            Parallel.ForEach(
+                transactions.Where(t => t.Amount < 0 && t.Account.AccountType != AccountType.CreditCard).ToList(),
+                t =>
+                {
+                    if (!ledgerBuckets.ContainsKey(t.BudgetBucket))
+                    {
+                        return;
+                    }
+                    Account.Account ledgerAccount = ledgerBuckets[t.BudgetBucket];
+                    if (t.Account != ledgerAccount)
+                    {
+                        lock (syncRoot)
+                        {
+                            toDoList.Add(
+                                new TransferTask(
+                                    $"A {t.BudgetBucket.Code} payment for {t.Amount:C} has been made from {t.Account}, but funds are stored in {ledgerAccount}.",
+                                    true)
+                                {
+                                    Amount = t.Amount,
+                                    SourceAccount = ledgerAccount,
+                                    DestinationAccount = t.Account
+                                });
+                        }
+                    }
+                });
+        }
+
+        /// <summary>
+        ///     An overdrawn surplus balance is not valid, and indicates that one or more ledger buckets have been overdrawn.  A
+        ///     transfer probably needs to be manually done by the user.
+        /// </summary>
+        private void CreateToDoForAnyOverdrawnSurplusBalance(ToDoCollection toDoList)
+        {
+            foreach (BankBalance surplusBalance in this.newReconciliationLine.SurplusBalances.Where(s => s.Balance < 0))
+            {
+                toDoList.Add(
+                    new ToDoTask(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "{0} has a negative surplus balance {1}, there must be one or more transfers to action.",
+                            surplusBalance.Account,
+                            surplusBalance.Balance),
+                        true));
+            }
+        }
+
+        private List<LedgerTransaction> IncludeBudgetedAmount(BudgetModel currentBudget, LedgerBucket ledgerBucket, DateTime reconciliationDate, ToDoCollection toDoList)
+        {
+            Expense budgetedExpense = currentBudget.Expenses.FirstOrDefault(e => e.Bucket.Code == ledgerBucket.BudgetBucket.Code);
+            var transactions = new List<LedgerTransaction>();
+            if (budgetedExpense != null)
+            {
+                BudgetCreditLedgerTransaction budgetedAmount;
+                if (ledgerBucket.StoredInAccount.IsSalaryAccount)
+                {
+                    budgetedAmount = new BudgetCreditLedgerTransaction
+                    {
+                        Amount = budgetedExpense.Bucket.Active ? budgetedExpense.Amount : 0,
+                        Narrative = budgetedExpense.Bucket.Active ? "Budgeted Amount" : "Warning! Bucket has been disabled."
+                    };
+                }
+                else
+                {
+                    budgetedAmount = new BudgetCreditLedgerTransaction
+                    {
+                        Amount = budgetedExpense.Bucket.Active ? budgetedExpense.Amount : 0,
+                        Narrative =
+                            budgetedExpense.Bucket.Active
+                                ? "Budget amount must be transferred into this account with a bank transfer, use the reference number for the transfer."
+                                : "Warning! Bucket has been disabled.",
+                        AutoMatchingReference = IssueTransactionReferenceNumber()
+                    };
+                    // TODO Maybe the budget should know which account the incomes go into, perhaps mapped against each income?
+                    Account.Account salaryAccount = this.newReconciliationLine.BankBalances.Single(b => b.Account.IsSalaryAccount).Account;
+                    toDoList.Add(
+                        new TransferTask(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                "For {0} transfer {1:C} from Salary Account to {2} with auto-matching reference: {3}",
+                                budgetedExpense.Bucket.Code,
+                                budgetedAmount.Amount,
+                                ledgerBucket.StoredInAccount,
+                                budgetedAmount.AutoMatchingReference),
+                            true)
+                        { Amount = budgetedAmount.Amount, SourceAccount = salaryAccount, DestinationAccount = ledgerBucket.StoredInAccount });
+                }
+
+                budgetedAmount.Date = reconciliationDate;
+                transactions.Add(budgetedAmount);
+            }
+
+            return transactions;
+        }
+    }
+}

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
@@ -443,7 +443,7 @@ namespace BudgetAnalyser.Engine.Ledger
                         new TransferTask(
                             string.Format(
                                 CultureInfo.CurrentCulture,
-                                "For {0} transfer {1:C} from Salary Account to {2} with auto-matching reference: {3}",
+                                "Budgeted Amount for {0} transfer {1:C} from Salary Account to {2} with auto-matching reference: {3}",
                                 budgetedExpense.Bucket.Code,
                                 budgetedAmount.Amount,
                                 ledgerBucket.StoredInAccount,

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationBuilder.cs
@@ -33,6 +33,26 @@ namespace BudgetAnalyser.Engine.Ledger
 
         public LedgerEntryLine CreateNewMonthlyReconciliation(DateTime reconciliationDateExcl, IEnumerable<BankBalance> bankBalances, BudgetModel budget, StatementModel statement, ToDoCollection toDoList)
         {
+            if (bankBalances == null)
+            {
+                throw new ArgumentNullException(nameof(bankBalances));
+            }
+
+            if (budget == null)
+            {
+                throw new ArgumentNullException(nameof(budget));
+            }
+
+            if (statement == null)
+            {
+                throw new ArgumentNullException(nameof(statement));
+            }
+
+            if (toDoList == null)
+            {
+                throw new ArgumentNullException(nameof(toDoList));
+            }
+
             if (LedgerBook == null)
             {
                 throw new ArgumentException("The Ledger Book property cannot be null. You must set this prior to calling this method.");

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationConsistency.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationConsistency.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+
+namespace BudgetAnalyser.Engine.Ledger
+{
+    public interface IReconciliationConsistency
+    {
+        IDisposable EnsureConsistency(LedgerBook book);
+    }
+
+    [AutoRegisterWithIoC]
+    public class ReconciliationConsistency : IReconciliationConsistency
+    {
+        public IDisposable EnsureConsistency(LedgerBook book)
+        {
+            return new ReconciliationConsistencyChecker { LedgerBook = book };
+        }
+    }
+
+    public class ReconciliationConsistencyChecker : IDisposable
+    {
+        private readonly decimal check1;
+        private decimal check2;
+
+        public ReconciliationConsistencyChecker()
+        {
+            this.check1 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
+        }
+
+        public LedgerBook LedgerBook { get; set; }
+
+        public void Dispose()
+        {
+            this.check2 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus) - LedgerBook.Reconciliations.First().CalculatedSurplus;
+            if (this.check1 != this.check2)
+            {
+                throw new CorruptedLedgerBookException("Code Error: The previous dated entries have changed, this is not allowed. Data is corrupt.");
+            }
+        }
+    }
+}

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationConsistency.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationConsistency.cs
@@ -1,41 +1,13 @@
 ﻿using System;
-using System.Linq;
 
 namespace BudgetAnalyser.Engine.Ledger
 {
-    public interface IReconciliationConsistency
-    {
-        IDisposable EnsureConsistency(LedgerBook book);
-    }
-
     [AutoRegisterWithIoC]
     public class ReconciliationConsistency : IReconciliationConsistency
     {
         public IDisposable EnsureConsistency(LedgerBook book)
         {
             return new ReconciliationConsistencyChecker { LedgerBook = book };
-        }
-    }
-
-    public class ReconciliationConsistencyChecker : IDisposable
-    {
-        private readonly decimal check1;
-        private decimal check2;
-
-        public ReconciliationConsistencyChecker()
-        {
-            this.check1 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
-        }
-
-        public LedgerBook LedgerBook { get; set; }
-
-        public void Dispose()
-        {
-            this.check2 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus) - LedgerBook.Reconciliations.First().CalculatedSurplus;
-            if (this.check1 != this.check2)
-            {
-                throw new CorruptedLedgerBookException("Code Error: The previous dated entries have changed, this is not allowed. Data is corrupt.");
-            }
         }
     }
 }

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationConsistency.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationConsistency.cs
@@ -3,11 +3,11 @@
 namespace BudgetAnalyser.Engine.Ledger
 {
     [AutoRegisterWithIoC]
-    public class ReconciliationConsistency : IReconciliationConsistency
+    internal class ReconciliationConsistency : IReconciliationConsistency
     {
         public IDisposable EnsureConsistency(LedgerBook book)
         {
-            return new ReconciliationConsistencyChecker { LedgerBook = book };
+            return new ReconciliationConsistencyChecker(book);
         }
     }
 }

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationConsistencyChecker.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationConsistencyChecker.cs
@@ -12,16 +12,17 @@ namespace BudgetAnalyser.Engine.Ledger
         private readonly decimal check1;
         private decimal check2;
 
-        public ReconciliationConsistencyChecker()
-        {
-            this.check1 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
-        }
+        private readonly LedgerBook ledgerBook;
 
-        public LedgerBook LedgerBook { get; set; }
+        public ReconciliationConsistencyChecker(LedgerBook book)
+        {
+            this.ledgerBook = book;
+            this.check1 = this.ledgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
+        }
 
         public void Dispose()
         {
-            this.check2 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus) - LedgerBook.Reconciliations.First().CalculatedSurplus;
+            this.check2 = this.ledgerBook.Reconciliations.Sum(e => e.CalculatedSurplus) - this.ledgerBook.Reconciliations.First().CalculatedSurplus;
             if (this.check1 != this.check2)
             {
                 throw new CorruptedLedgerBookException("Code Error: The previous dated entries have changed, this is not allowed. Data is corrupt.");

--- a/BudgetAnalyser.Engine/Ledger/ReconciliationConsistencyChecker.cs
+++ b/BudgetAnalyser.Engine/Ledger/ReconciliationConsistencyChecker.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+
+namespace BudgetAnalyser.Engine.Ledger
+{
+    /// <summary>
+    ///     This class is responsible for validating that changes were made during a reconciliation that did not alter the
+    ///     Ledger Book in an inappropriate and invalid way.
+    /// </summary>
+    public class ReconciliationConsistencyChecker : IDisposable
+    {
+        private readonly decimal check1;
+        private decimal check2;
+
+        public ReconciliationConsistencyChecker()
+        {
+            this.check1 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
+        }
+
+        public LedgerBook LedgerBook { get; set; }
+
+        public void Dispose()
+        {
+            this.check2 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus) - LedgerBook.Reconciliations.First().CalculatedSurplus;
+            if (this.check1 != this.check2)
+            {
+                throw new CorruptedLedgerBookException("Code Error: The previous dated entries have changed, this is not allowed. Data is corrupt.");
+            }
+        }
+    }
+}

--- a/BudgetAnalyser.Engine/Ledger/TransferTask.cs
+++ b/BudgetAnalyser.Engine/Ledger/TransferTask.cs
@@ -7,7 +7,9 @@ namespace BudgetAnalyser.Engine.Ledger
         }
 
         public decimal Amount { get; internal set; }
+        public string BucketCode { get; internal set; }
         public Account.Account DestinationAccount { get; internal set; }
+        public string Reference { get; internal set; }
         public Account.Account SourceAccount { get; internal set; }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/Data/MatchingAutoMapperConfiguration.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/MatchingAutoMapperConfiguration.cs
@@ -23,6 +23,7 @@ namespace BudgetAnalyser.Engine.Matching.Data
         {
             Mapper.CreateMap<MatchingRuleDto, MatchingRule>()
                 .ConstructUsing(dto => this.ruleFactory.CreateRuleForPersistence(dto.BucketCode))
+                .ForMember(rule => rule.Hidden, m => m.Ignore())
                 .ForMember(rule => rule.Bucket, m => m.Ignore())
                 .ForMember(rule => rule.Created, m => m.MapFrom(dto => dto.Created ?? DateTime.Now))
                 .ForMember(rule => rule.RuleId, m => m.MapFrom(dto => dto.RuleId ?? Guid.NewGuid()));

--- a/BudgetAnalyser.Engine/Matching/Data/MatchingAutoMapperConfiguration.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/MatchingAutoMapperConfiguration.cs
@@ -31,11 +31,10 @@ namespace BudgetAnalyser.Engine.Matching.Data
 
             Mapper.CreateMap<SingleUseMatchingRuleDto, SingleUseMatchingRule>()
                 .ConstructUsing(dto => this.ruleFactory.CreateSingleUseRuleForPersistence(dto.BucketCode))
-                .ForMember(rule => rule.Bucket, m => m.Ignore())
-                .ForMember(rule => rule.Created, m => m.MapFrom(dto => dto.Created ?? DateTime.Now))
-                .ForMember(rule => rule.RuleId, m => m.MapFrom(dto => dto.RuleId ?? Guid.NewGuid()));
+                .IncludeBase<MatchingRuleDto, MatchingRule>();
 
-            Mapper.CreateMap<SingleUseMatchingRule, SingleUseMatchingRuleDto>();
+            Mapper.CreateMap<SingleUseMatchingRule, SingleUseMatchingRuleDto>()
+                .IncludeBase<MatchingRule, MatchingRuleDto>();
         }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/Data/MatchingAutoMapperConfiguration.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/MatchingAutoMapperConfiguration.cs
@@ -22,12 +22,20 @@ namespace BudgetAnalyser.Engine.Matching.Data
         public void RegisterMappings()
         {
             Mapper.CreateMap<MatchingRuleDto, MatchingRule>()
-                .ConstructUsing(dto => this.ruleFactory.CreateRule(dto.BucketCode))
+                .ConstructUsing(dto => this.ruleFactory.CreateRuleForPersistence(dto.BucketCode))
                 .ForMember(rule => rule.Bucket, m => m.Ignore())
                 .ForMember(rule => rule.Created, m => m.MapFrom(dto => dto.Created ?? DateTime.Now))
                 .ForMember(rule => rule.RuleId, m => m.MapFrom(dto => dto.RuleId ?? Guid.NewGuid()));
 
             Mapper.CreateMap<MatchingRule, MatchingRuleDto>();
+
+            Mapper.CreateMap<SingleUseMatchingRuleDto, SingleUseMatchingRule>()
+                .ConstructUsing(dto => this.ruleFactory.CreateSingleUseRuleForPersistence(dto.BucketCode))
+                .ForMember(rule => rule.Bucket, m => m.Ignore())
+                .ForMember(rule => rule.Created, m => m.MapFrom(dto => dto.Created ?? DateTime.Now))
+                .ForMember(rule => rule.RuleId, m => m.MapFrom(dto => dto.RuleId ?? Guid.NewGuid()));
+
+            Mapper.CreateMap<SingleUseMatchingRule, SingleUseMatchingRuleDto>();
         }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
@@ -1,0 +1,6 @@
+﻿namespace BudgetAnalyser.Engine.Matching.Data
+{
+    public class SingleUseMatchingRuleDto : MatchingRuleDto
+    {
+    }
+}

--- a/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
@@ -2,6 +2,5 @@
 {
     public class SingleUseMatchingRuleDto : MatchingRuleDto
     {
-        public int Lifetime { get; set; }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
@@ -1,10 +1,7 @@
-﻿using BudgetAnalyser.Engine.Annotations;
-
-namespace BudgetAnalyser.Engine.Matching.Data
+﻿namespace BudgetAnalyser.Engine.Matching.Data
 {
     public class SingleUseMatchingRuleDto : MatchingRuleDto
     {
-        [UsedImplicitly]
         public int Lifetime { get; set; }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
@@ -2,5 +2,6 @@
 {
     public class SingleUseMatchingRuleDto : MatchingRuleDto
     {
+        public int Lifetime { get; set; }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
+++ b/BudgetAnalyser.Engine/Matching/Data/SingleUseMatchingRuleDto.cs
@@ -1,7 +1,10 @@
-﻿namespace BudgetAnalyser.Engine.Matching.Data
+﻿using BudgetAnalyser.Engine.Annotations;
+
+namespace BudgetAnalyser.Engine.Matching.Data
 {
     public class SingleUseMatchingRuleDto : MatchingRuleDto
     {
+        [UsedImplicitly]
         public int Lifetime { get; set; }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/IMatchingRuleFactory.cs
+++ b/BudgetAnalyser.Engine/Matching/IMatchingRuleFactory.cs
@@ -4,10 +4,24 @@ namespace BudgetAnalyser.Engine.Matching
 {
     public interface IMatchingRuleFactory
     {
+        MatchingRule CreateNewRule(
+            [NotNull] string bucketCode,
+            [CanBeNull] string description,
+            [CanBeNull] string[] references,
+            [CanBeNull] string transactionTypeName,
+            [CanBeNull] decimal? amount,
+            bool andMatching);
+
+        SingleUseMatchingRule CreateNewSingleUseRule(
+            [NotNull] string bucketCode,
+            [CanBeNull] string description,
+            [CanBeNull] string[] references,
+            [CanBeNull] string transactionTypeName,
+            [CanBeNull] decimal? amount,
+            bool andMatching,
+            int lifetime = 1);
+
         MatchingRule CreateRuleForPersistence([NotNull] string budgetBucketCode);
         SingleUseMatchingRule CreateSingleUseRuleForPersistence([NotNull] string budgetBucketCode);
-
-        MatchingRule CreateNewRule([NotNull] string bucketCode, [CanBeNull] string description, [CanBeNull] string[] references, [CanBeNull] string transactionTypeName, [CanBeNull] decimal? amount, bool andMatching);
-        SingleUseMatchingRule CreateNewSingleUseRule([NotNull] string bucketCode, [CanBeNull] string description, [CanBeNull] string[] references, [CanBeNull] string transactionTypeName, [CanBeNull] decimal? amount, bool andMatching);
     }
 }

--- a/BudgetAnalyser.Engine/Matching/IMatchingRuleFactory.cs
+++ b/BudgetAnalyser.Engine/Matching/IMatchingRuleFactory.cs
@@ -1,7 +1,13 @@
-﻿namespace BudgetAnalyser.Engine.Matching
+﻿using BudgetAnalyser.Engine.Annotations;
+
+namespace BudgetAnalyser.Engine.Matching
 {
     public interface IMatchingRuleFactory
     {
-        MatchingRule CreateRule(string budgetBucketCode);
+        MatchingRule CreateRuleForPersistence([NotNull] string budgetBucketCode);
+        SingleUseMatchingRule CreateSingleUseRuleForPersistence([NotNull] string budgetBucketCode);
+
+        MatchingRule CreateNewRule([NotNull] string bucketCode, [CanBeNull] string description, [CanBeNull] string[] references, [CanBeNull] string transactionTypeName, [CanBeNull] decimal? amount, bool andMatching);
+        SingleUseMatchingRule CreateNewSingleUseRule([NotNull] string bucketCode, [CanBeNull] string description, [CanBeNull] string[] references, [CanBeNull] string transactionTypeName, [CanBeNull] decimal? amount, bool andMatching);
     }
 }

--- a/BudgetAnalyser.Engine/Matching/IMatchingRuleFactory.cs
+++ b/BudgetAnalyser.Engine/Matching/IMatchingRuleFactory.cs
@@ -18,8 +18,7 @@ namespace BudgetAnalyser.Engine.Matching
             [CanBeNull] string[] references,
             [CanBeNull] string transactionTypeName,
             [CanBeNull] decimal? amount,
-            bool andMatching,
-            int lifetime = 1);
+            bool andMatching);
 
         MatchingRule CreateRuleForPersistence([NotNull] string budgetBucketCode);
         SingleUseMatchingRule CreateSingleUseRuleForPersistence([NotNull] string budgetBucketCode);

--- a/BudgetAnalyser.Engine/Matching/MatchingRule.cs
+++ b/BudgetAnalyser.Engine/Matching/MatchingRule.cs
@@ -10,6 +10,9 @@ using BudgetAnalyser.Engine.Statement;
 
 namespace BudgetAnalyser.Engine.Matching
 {
+    /// <summary>
+    /// An instance of this class describes how and if a transaction can be automatically matched to a Bucket when auto-matching rules are applied.
+    /// </summary>
     [DebuggerDisplay("Rule: {Description} {RuleId} {BucketCode")]
     public class MatchingRule : INotifyPropertyChanged, IEquatable<MatchingRule>
     {
@@ -24,11 +27,6 @@ namespace BudgetAnalyser.Engine.Matching
         private string doNotUseReference3;
         private string doNotUseTransactionType;
 
-        /// <summary>
-        ///     Used any other time.
-        /// </summary>
-        /// <param name="bucketRepository"></param>
-        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "Reviewed, ok here")]
         public MatchingRule([NotNull] IBudgetBucketRepository bucketRepository)
         {
             if (bucketRepository == null)

--- a/BudgetAnalyser.Engine/Matching/MatchingRule.cs
+++ b/BudgetAnalyser.Engine/Matching/MatchingRule.cs
@@ -13,7 +13,7 @@ namespace BudgetAnalyser.Engine.Matching
     /// <summary>
     /// An instance of this class describes how and if a transaction can be automatically matched to a Bucket when auto-matching rules are applied.
     /// </summary>
-    [DebuggerDisplay("Rule: {Description} {RuleId} {BucketCode")]
+    [DebuggerDisplay("Rule: {Description} {RuleId} {BucketCode}")]
     public class MatchingRule : INotifyPropertyChanged, IEquatable<MatchingRule>
     {
         private readonly IBudgetBucketRepository bucketRepository;
@@ -41,6 +41,8 @@ namespace BudgetAnalyser.Engine.Matching
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
+
+        public bool Hidden { get; set; }
 
         public decimal? Amount
         {
@@ -298,7 +300,7 @@ namespace BudgetAnalyser.Engine.Matching
 
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture, "MatchingRule({0} {1} {2})", Bucket.Code, Description, Amount);
+            return string.Format(CultureInfo.CurrentCulture, "{0}({1} {2} {3})", GetType().Name, Bucket.Code, Description, Amount);
         }
 
         [NotifyPropertyChangedInvocator]

--- a/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
+++ b/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using BudgetAnalyser.Engine.Annotations;
 using BudgetAnalyser.Engine.Budget;
 
@@ -53,16 +54,32 @@ namespace BudgetAnalyser.Engine.Matching
                 throw new ArgumentNullException(nameof(references));
             }
 
-            if (references.Length != 3)
+            if (references.Length > 3)
             {
                 throw new ArgumentException("The references array is expected to contain 3 elements.");
             }
 
+            var adjustedReferences = new List<string>();
+            if (references.Length < 3)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    if (i <= references.GetUpperBound(0))
+                    {
+                        adjustedReferences.Add(references[i]);
+                    }
+                    else
+                    {
+                        adjustedReferences.Add(null);
+                    }
+                }
+            }
+
             T newRule = ruleCtor(bucketCode);
             newRule.Description = description;
-            newRule.Reference1 = references[0];
-            newRule.Reference2 = references[1];
-            newRule.Reference3 = references[2];
+            newRule.Reference1 = adjustedReferences[0];
+            newRule.Reference2 = adjustedReferences[1];
+            newRule.Reference3 = adjustedReferences[2];
             newRule.Amount = amount;
             newRule.TransactionType = transactionTypeName;
             newRule.And = andMatching;

--- a/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
+++ b/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
@@ -24,10 +24,9 @@ namespace BudgetAnalyser.Engine.Matching
             return CreateAnyNewRule(CreateRuleForPersistence, bucketCode, description, references, transactionTypeName, amount, andMatching);
         }
 
-        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching, int lifetime = 1)
+        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
         {
             var rule = CreateAnyNewRule(CreateSingleUseRuleForPersistence, bucketCode, description, references, transactionTypeName, amount, andMatching);
-            rule.Lifetime = lifetime;
             return rule;
         }
 

--- a/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
+++ b/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
@@ -24,9 +24,11 @@ namespace BudgetAnalyser.Engine.Matching
             return CreateAnyNewRule(CreateRuleForPersistence, bucketCode, description, references, transactionTypeName, amount, andMatching);
         }
 
-        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
+        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching, int lifetime = 1)
         {
-            return CreateAnyNewRule(CreateSingleUseRuleForPersistence, bucketCode, description, references, transactionTypeName, amount, andMatching);
+            var rule = CreateAnyNewRule(CreateSingleUseRuleForPersistence, bucketCode, description, references, transactionTypeName, amount, andMatching);
+            rule.Lifetime = lifetime;
+            return rule;
         }
 
         public MatchingRule CreateRuleForPersistence(string budgetBucketCode)

--- a/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
+++ b/BudgetAnalyser.Engine/Matching/MatchingRuleFactory.cs
@@ -19,9 +19,53 @@ namespace BudgetAnalyser.Engine.Matching
             this.bucketRepo = bucketRepo;
         }
 
-        public MatchingRule CreateRule(string budgetBucketCode)
+        public MatchingRule CreateNewRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
+        {
+            return CreateAnyNewRule(CreateRuleForPersistence, bucketCode, description, references, transactionTypeName, amount, andMatching);
+        }
+
+        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
+        {
+            return CreateAnyNewRule(CreateSingleUseRuleForPersistence, bucketCode, description, references, transactionTypeName, amount, andMatching);
+        }
+
+        public MatchingRule CreateRuleForPersistence(string budgetBucketCode)
         {
             return new MatchingRule(this.bucketRepo) { BucketCode = budgetBucketCode };
+        }
+
+        public SingleUseMatchingRule CreateSingleUseRuleForPersistence(string budgetBucketCode)
+        {
+            return new SingleUseMatchingRule(this.bucketRepo) { BucketCode = budgetBucketCode };
+        }
+
+        private T CreateAnyNewRule<T>(Func<string, T> ruleCtor, string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
+            where T : MatchingRule
+        {
+            if (string.IsNullOrEmpty(bucketCode))
+            {
+                throw new ArgumentNullException(nameof(bucketCode));
+            }
+
+            if (references == null)
+            {
+                throw new ArgumentNullException(nameof(references));
+            }
+
+            if (references.Length != 3)
+            {
+                throw new ArgumentException("The references array is expected to contain 3 elements.");
+            }
+
+            T newRule = ruleCtor(bucketCode);
+            newRule.Description = description;
+            newRule.Reference1 = references[0];
+            newRule.Reference2 = references[1];
+            newRule.Reference3 = references[2];
+            newRule.Amount = amount;
+            newRule.TransactionType = transactionTypeName;
+            newRule.And = andMatching;
+            return newRule;
         }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
+++ b/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
@@ -1,16 +1,25 @@
-﻿using BudgetAnalyser.Engine.Annotations;
+﻿using System;
+using BudgetAnalyser.Engine.Annotations;
 using BudgetAnalyser.Engine.Budget;
 
 namespace BudgetAnalyser.Engine.Matching
 {
     /// <summary>
-    /// A matching rule that is applied only once then deleted.
-    /// For example: Used to match system generated transactions with a unique reference code.
+    ///     A matching rule that is applied only once then deleted.
+    ///     For example: Used to match system generated transactions with a unique reference code.
     /// </summary>
     public class SingleUseMatchingRule : MatchingRule
     {
-        public SingleUseMatchingRule([NotNull] IBudgetBucketRepository bucketRepository) : base(bucketRepository)
+        public SingleUseMatchingRule([NotNull] IBudgetBucketRepository bucketRepository, int lifeTimeMatchTarget = 1) : base(bucketRepository)
         {
+            if (lifeTimeMatchTarget <= 0) throw new ArgumentException($"Invalid value for '{nameof(lifeTimeMatchTarget)}' : {lifeTimeMatchTarget}, it must be 1 or greater.");
+            Lifetime = lifeTimeMatchTarget;
         }
+
+        /// <summary>
+        ///     The match count target. After reaching this target the rule will automatically be deleted.
+        ///     Defaults to 1.
+        /// </summary>
+        public int Lifetime { get; set; }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
+++ b/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
@@ -1,0 +1,16 @@
+﻿using BudgetAnalyser.Engine.Annotations;
+using BudgetAnalyser.Engine.Budget;
+
+namespace BudgetAnalyser.Engine.Matching
+{
+    /// <summary>
+    /// A matching rule that is applied only once then deleted.
+    /// For example: Used to match system generated transactions with a unique reference code.
+    /// </summary>
+    public class SingleUseMatchingRule : MatchingRule
+    {
+        public SingleUseMatchingRule([NotNull] IBudgetBucketRepository bucketRepository) : base(bucketRepository)
+        {
+        }
+    }
+}

--- a/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
+++ b/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
@@ -10,17 +10,9 @@ namespace BudgetAnalyser.Engine.Matching
     /// </summary>
     public class SingleUseMatchingRule : MatchingRule
     {
-        public SingleUseMatchingRule([NotNull] IBudgetBucketRepository bucketRepository, int lifeTimeMatchTarget = 1) : base(bucketRepository)
+        public SingleUseMatchingRule([NotNull] IBudgetBucketRepository bucketRepository) : base(bucketRepository)
         {
-            if (lifeTimeMatchTarget <= 0) throw new ArgumentException($"Invalid value for '{nameof(lifeTimeMatchTarget)}' : {lifeTimeMatchTarget}, it must be 1 or greater.");
-            Lifetime = lifeTimeMatchTarget;
             Hidden = true;
         }
-
-        /// <summary>
-        ///     The match count target. After reaching this target the rule will automatically be deleted.
-        ///     Defaults to 1.
-        /// </summary>
-        public int Lifetime { get; set; }
     }
 }

--- a/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
+++ b/BudgetAnalyser.Engine/Matching/SingleUseMatchingRule.cs
@@ -14,6 +14,7 @@ namespace BudgetAnalyser.Engine.Matching
         {
             if (lifeTimeMatchTarget <= 0) throw new ArgumentException($"Invalid value for '{nameof(lifeTimeMatchTarget)}' : {lifeTimeMatchTarget}, it must be 1 or greater.");
             Lifetime = lifeTimeMatchTarget;
+            Hidden = true;
         }
 
         /// <summary>

--- a/BudgetAnalyser.Engine/Services/ApplicationDatabaseService.cs
+++ b/BudgetAnalyser.Engine/Services/ApplicationDatabaseService.cs
@@ -151,6 +151,9 @@ namespace BudgetAnalyser.Engine.Services
                 .ToList()
                 .ForEach(service => service.SavePreview(contexts));
 
+            // This clears all the temporary tasks from the collection.  Only tasks that have CanDelete=false will be kept and saved.
+            this.budgetAnalyserDatabase.LedgerReconciliationToDoCollection.Clear();
+
             // Save the main application repository first.
             await this.applicationRepository.SaveAsync(this.budgetAnalyserDatabase);
 

--- a/BudgetAnalyser.Engine/Services/ILedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/ILedgerService.cs
@@ -40,13 +40,12 @@ namespace BudgetAnalyser.Engine.Services
         /// <summary>
         ///     Creates a new LedgerEntryLine for the specified <see cref="LedgerBook" /> to begin reconciliation.
         /// </summary>
-        /// <param name="reconciliationDateIfFirstEver">
-        ///     The date for the <see cref="LedgerEntryLine" />. Also used to search for transactions in the
-        ///     <see cref="statement" />. This date ideally is your payday of the month, and should be the same date
-        ///     every month. Transactions are searched for up to but not including this date.
+        /// <param name="reconciliationStartDate">
+        ///     The startDate for the <see cref="LedgerEntryLine" />. This is usually the previous Month's "Reconciliation-Date", as this month's reconciliation starts with this date and includes transactions
+        ///     from that date. This date is different to the "Reconciliation-Date" that appears next to the resulting reconciliation which is the end date for the period.
         /// </param>
         /// <param name="balances">
-        ///     The bank balances as at the <see cref="reconciliationDateIfFirstEver" /> to include in this new single line of the
+        ///     The bank balances as at the <see cref="reconciliationStartDate" /> to include in this new single line of the
         ///     ledger book.
         /// </param>
         /// <param name="budgetContext">The current budget context.</param>
@@ -54,7 +53,7 @@ namespace BudgetAnalyser.Engine.Services
         /// <param name="ignoreWarnings">Ignores validation warnings if true, otherwise <see cref="ValidationWarningException" />.</param>
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="LedgerBook" /> is in an invalid state.</exception>
         LedgerEntryLine MonthEndReconciliation(
-            DateTime reconciliationDateIfFirstEver,
+            DateTime reconciliationStartDate,
             [NotNull] IEnumerable<BankBalance> balances,
             [NotNull] IBudgetCurrencyContext budgetContext,
             [NotNull] StatementModel statement,

--- a/BudgetAnalyser.Engine/Services/ILedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/ILedgerService.cs
@@ -40,7 +40,7 @@ namespace BudgetAnalyser.Engine.Services
         /// <summary>
         ///     Creates a new LedgerEntryLine for the specified <see cref="LedgerBook" /> to begin reconciliation.
         /// </summary>
-        /// <param name="reconciliationStartDate">
+        /// <param name="reconciliationDatetDate">
         ///     The startDate for the <see cref="LedgerEntryLine" />. This is usually the previous Month's "Reconciliation-Date", as this month's reconciliation starts with this date and includes transactions
         ///     from that date. This date is different to the "Reconciliation-Date" that appears next to the resulting reconciliation which is the end date for the period.
         /// </param>
@@ -53,7 +53,7 @@ namespace BudgetAnalyser.Engine.Services
         /// <param name="ignoreWarnings">Ignores validation warnings if true, otherwise <see cref="ValidationWarningException" />.</param>
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="LedgerBook" /> is in an invalid state.</exception>
         LedgerEntryLine MonthEndReconciliation(
-            DateTime reconciliationStartDate,
+            DateTime reconciliationDate,
             [NotNull] IEnumerable<BankBalance> balances,
             [NotNull] IBudgetCurrencyContext budgetContext,
             [NotNull] StatementModel statement,

--- a/BudgetAnalyser.Engine/Services/ITransactionRuleService.cs
+++ b/BudgetAnalyser.Engine/Services/ITransactionRuleService.cs
@@ -49,7 +49,6 @@ namespace BudgetAnalyser.Engine.Services
         ///     If true, they are matched using an AND operator and all elements must be matched for the rule to match the
         ///     transaction. Otherwise chosen elements are matched using an OR operator.
         /// </param>
-        /// <param name="lifetime">The match count target. After reaching this target the rule will automatically be deleted. Defaults to 1.</param>
         /// <returns>The new matching rule.</returns>
         SingleUseMatchingRule CreateNewSingleUseRule(
             [NotNull] string bucketCode,
@@ -57,8 +56,7 @@ namespace BudgetAnalyser.Engine.Services
             [NotNull] string[] references,
             [CanBeNull] string transactionTypeName,
             [CanBeNull] decimal? amount,
-            bool andMatching,
-            int lifetime = 1);
+            bool andMatching);
 
         /// <summary>
         ///     Determines whether a rule similar to the input values.

--- a/BudgetAnalyser.Engine/Services/ITransactionRuleService.cs
+++ b/BudgetAnalyser.Engine/Services/ITransactionRuleService.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using BudgetAnalyser.Engine.Annotations;
-using BudgetAnalyser.Engine.Budget;
 using BudgetAnalyser.Engine.Matching;
 using BudgetAnalyser.Engine.Statement;
 
@@ -18,23 +17,9 @@ namespace BudgetAnalyser.Engine.Services
         ObservableCollection<RulesGroupedByBucket> MatchingRulesGroupedByBucket { get; }
 
         /// <summary>
-        ///     Adds a new rule to the currently loaded set. Will also immediately persist the matching rule set.
-        /// </summary>
-        /// <param name="ruleToAdd">The rule to add.</param>
-        /// <returns>True if the rule was added successfully, otherwise false to indicate the rule already exists.</returns>
-        /// <exception cref="System.ArgumentNullException">
-        ///     <paramref name="ruleToAdd" />
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        ///     Will be thrown when the service has not yet been initialised by calling
-        ///     <see cref="ISupportsModelPersistence.LoadAsync" />
-        /// </exception>
-        bool AddRule([NotNull] MatchingRule ruleToAdd);
-
-        /// <summary>
         ///     Creates a new matching rule.
         /// </summary>
-        /// <param name="bucket">The budget bucket to match transactions to.</param>
+        /// <param name="bucketCode">The budget bucket to match transactions to.</param>
         /// <param name="description">The description to match. If null, it will not be used to match.</param>
         /// <param name="references">The references to match. If null, it will not be used to match.</param>
         /// <param name="transactionTypeName">Name of the transaction type to match. If null, it will not be used to match.</param>
@@ -45,7 +30,28 @@ namespace BudgetAnalyser.Engine.Services
         /// </param>
         /// <returns>The new matching rule.</returns>
         MatchingRule CreateNewRule(
-            [NotNull] BudgetBucket bucket,
+            [NotNull] string bucketCode,
+            [CanBeNull] string description,
+            [NotNull] string[] references,
+            [CanBeNull] string transactionTypeName,
+            [CanBeNull] decimal? amount,
+            bool andMatching);
+
+        /// <summary>
+        ///     Creates a new single use matching rule. (One that will be deleted after it is used to make a match).
+        /// </summary>
+        /// <param name="bucketCode">The budget bucket code to match transactions to.</param>
+        /// <param name="description">The description to match. If null, it will not be used to match.</param>
+        /// <param name="references">The references to match. If null, it will not be used to match.</param>
+        /// <param name="transactionTypeName">Name of the transaction type to match. If null, it will not be used to match.</param>
+        /// <param name="amount">The exact amount to match.</param>
+        /// <param name="andMatching">
+        ///     If true, they are matched using an AND operator and all elements must be matched for the rule to match the
+        ///     transaction. Otherwise chosen elements are matched using an OR operator.
+        /// </param>
+        /// <returns>The new matching rule.</returns>
+        SingleUseMatchingRule CreateNewSingleUseRule(
+            [NotNull] string bucketCode,
             [CanBeNull] string description,
             [NotNull] string[] references,
             [CanBeNull] string transactionTypeName,

--- a/BudgetAnalyser.Engine/Services/ITransactionRuleService.cs
+++ b/BudgetAnalyser.Engine/Services/ITransactionRuleService.cs
@@ -49,6 +49,7 @@ namespace BudgetAnalyser.Engine.Services
         ///     If true, they are matched using an AND operator and all elements must be matched for the rule to match the
         ///     transaction. Otherwise chosen elements are matched using an OR operator.
         /// </param>
+        /// <param name="lifetime">The match count target. After reaching this target the rule will automatically be deleted. Defaults to 1.</param>
         /// <returns>The new matching rule.</returns>
         SingleUseMatchingRule CreateNewSingleUseRule(
             [NotNull] string bucketCode,
@@ -56,7 +57,8 @@ namespace BudgetAnalyser.Engine.Services
             [NotNull] string[] references,
             [CanBeNull] string transactionTypeName,
             [CanBeNull] decimal? amount,
-            bool andMatching);
+            bool andMatching,
+            int lifetime = 1);
 
         /// <summary>
         ///     Determines whether a rule similar to the input values.

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -203,7 +203,7 @@ namespace BudgetAnalyser.Engine.Services
                 var transferTask = task as TransferTask;
                 if (transferTask != null && transferTask.SystemGenerated && transferTask.Reference.IsSomething())
                 {
-                    this.transactionRuleService.CreateNewSingleUseRule(transferTask.BucketCode, null, new[] { transferTask.Reference }, null, transferTask.Amount, true);
+                    this.transactionRuleService.CreateNewSingleUseRule(transferTask.BucketCode, null, new[] { transferTask.Reference }, null, null, true, 2);
                 }
             }
 

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -167,7 +169,7 @@ namespace BudgetAnalyser.Engine.Services
         }
 
         public LedgerEntryLine MonthEndReconciliation(
-            DateTime reconciliationStartDate,
+            DateTime reconciliationDate,
             IEnumerable<BankBalance> balances,
             IBudgetCurrencyContext budgetContext,
             StatementModel statement,
@@ -196,7 +198,32 @@ namespace BudgetAnalyser.Engine.Services
             ReconciliationToDoList.Clear();
             Stopwatch stopWatch = Stopwatch.StartNew();
             this.logger.LogInfo(l => l.Format("Starting Ledger Book reconciliation {0}", DateTime.Now));
-            LedgerEntryLine recon = LedgerBook.Reconcile(reconciliationStartDate, balances, budgetContext.Model, ReconciliationToDoList, statement, ignoreWarnings);
+
+            try
+            {
+                PreReconciliationValidation(reconciliationDate, statement);
+            }
+            catch (ValidationWarningException)
+            {
+                if (!ignoreWarnings)
+                {
+                    throw;
+                }
+            }
+
+            if (ReconciliationToDoList == null)
+            {
+                ReconciliationToDoList = new ToDoCollection();
+            }
+
+            decimal consistencyCheck1 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
+            LedgerEntryLine recon = LedgerBook.Reconcile(reconciliationDate, balances, budgetContext.Model, ReconciliationToDoList, statement);
+            decimal consistencyCheck2 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
+            if (consistencyCheck1 != consistencyCheck2)
+            {
+                throw new CorruptedLedgerBookException("Code Error: The previous dated entries have changed, this is not allowed. Data is corrupt.");
+            }
+
             foreach (ToDoTask task in ReconciliationToDoList)
             {
                 this.logger.LogInfo(l => l.Format("TASK: {0} SystemGenerated:{1}", task.Description, task.SystemGenerated));
@@ -331,6 +358,121 @@ namespace BudgetAnalyser.Engine.Services
         public IEnumerable<Account.Account> ValidLedgerAccounts()
         {
             return this.accountTypeRepository.ListCurrentlyUsedAccountTypes();
+        }
+
+        private void PreReconciliationValidation(DateTime reconciliationDate, StatementModel statement)
+        {
+            var messages = new StringBuilder();
+            if (!LedgerBook.Validate(messages))
+            {
+                throw new InvalidOperationException("Ledger book is currently in an invalid state. Cannot add new entries.\n" + messages);
+            }
+
+            if (statement == null)
+            {
+                return;
+            }
+
+            var startDate = ReconciliationBuilder.CalculateDateForReconcile(LedgerBook, reconciliationDate);
+
+            ValidateDates(startDate, reconciliationDate, statement);
+
+            ValidateAgainstUncategorisedTransactions(startDate, reconciliationDate, statement);
+
+            ValidateAgainstOrphanedAutoMatchingTransactions(statement);
+        }
+
+        private void ValidateAgainstOrphanedAutoMatchingTransactions(StatementModel statement)
+        {
+            LedgerEntryLine lastLine = LedgerBook.Reconciliations.FirstOrDefault();
+            if (lastLine == null)
+            {
+                return;
+            }
+
+            List<LedgerTransaction> unmatchedTxns = lastLine.Entries
+                .SelectMany(e => e.Transactions)
+                .Where(t => !string.IsNullOrWhiteSpace(t.AutoMatchingReference) && !t.AutoMatchingReference.StartsWith(ReconciliationBuilder.MatchedPrefix, StringComparison.Ordinal))
+                .ToList();
+
+            if (unmatchedTxns.None())
+            {
+                return;
+            }
+
+            List<Transaction> statementSubSet = statement.AllTransactions.Where(t => t.Date >= lastLine.Date).ToList();
+            foreach (LedgerTransaction ledgerTransaction in unmatchedTxns)
+            {
+                IEnumerable<Transaction> statementTxns = ReconciliationBuilder.TransactionsToAutoMatch(statementSubSet, ledgerTransaction.AutoMatchingReference);
+                if (statementTxns.None())
+                {
+                    this.logger.LogWarning(
+                        l =>
+                            l.Format(
+                                "There appears to be some transactions from last month that should be auto-matched to a statement transactions, but no matching statement transactions were found. {0}",
+                                ledgerTransaction));
+                    throw new ValidationWarningException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            "There appears to be some transactions from last month that should be auto-matched to a statement transactions, but no matching statement transactions were found.\nHave you forgotten to do a transfer?\nTransaction ID:{0} Ref:{1} Amount:{2:C}",
+                            ledgerTransaction.Id,
+                            ledgerTransaction.AutoMatchingReference,
+                            ledgerTransaction.Amount));
+                }
+            }
+        }
+
+        private void ValidateAgainstUncategorisedTransactions(DateTime startDate, DateTime reconciliationDate, StatementModel statement)
+        {
+            if (statement.AllTransactions
+                .Where(t => t.Date >= startDate && t.Date < reconciliationDate)
+                .Any(t => t.BudgetBucket == null || (t.BudgetBucket != null && string.IsNullOrWhiteSpace(t.BudgetBucket.Code))))
+            {
+                IEnumerable<Transaction> uncategorised = statement.AllTransactions.Where(t => t.BudgetBucket == null || (t.BudgetBucket != null && string.IsNullOrWhiteSpace(t.BudgetBucket.Code)));
+                var count = 0;
+                this.logger.LogWarning(_ => "LedgerBook.PreReconciliationValidation: There appears to be transactions in the statement that are not categorised into a budget bucket.");
+                foreach (Transaction transaction in uncategorised)
+                {
+                    count++;
+                    Transaction transactionCopy = transaction;
+                    this.logger.LogWarning(_ => "LedgerBook.PreReconciliationValidation: Transaction: " + transactionCopy.Id + transactionCopy.BudgetBucket);
+                    if (count > 5)
+                    {
+                        this.logger.LogWarning(_ => "LedgerBook.PreReconciliationValidation: There are more than 5 transactions.");
+                    }
+                }
+
+                throw new ValidationWarningException("There appears to be transactions in the statement that are not categorised into a budget bucket.");
+            }
+        }
+
+        [SuppressMessage("ReSharper", "UnusedParameter.Local")]
+        private void ValidateDates(DateTime startDate, DateTime reconciliationDate, StatementModel statement)
+        {
+            LedgerEntryLine recentEntry = LedgerBook.Reconciliations.FirstOrDefault();
+            if (recentEntry != null)
+            {
+                if (reconciliationDate <= recentEntry.Date)
+                {
+                    throw new InvalidOperationException("The start Date entered is before the previous ledger entry.");
+                }
+
+                if (recentEntry.Date.AddDays(7 * 4) > reconciliationDate)
+                {
+                    throw new InvalidOperationException("The start Date entered is not at least 4 weeks after the previous reconciliation. ");
+                }
+
+                if (recentEntry.Date.Day != reconciliationDate.Day)
+                {
+                    throw new ValidationWarningException(
+                        "The reconciliation Date chosen, {0}, isn't the same day of the month as the previous entry {1}. Not required, but ideally reconciliations should be evenly spaced.");
+                }
+            }
+
+            if (!statement.AllTransactions.Any(t => t.Date >= startDate))
+            {
+                throw new ValidationWarningException("There doesn't appear to be any transactions in the statement for the month up to " + reconciliationDate.ToShortDateString());
+            }
         }
     }
 }

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -218,7 +218,7 @@ namespace BudgetAnalyser.Engine.Services
 
             decimal consistencyCheck1 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
             LedgerEntryLine recon = LedgerBook.Reconcile(reconciliationDate, balances, budgetContext.Model, ReconciliationToDoList, statement);
-            decimal consistencyCheck2 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus);
+            decimal consistencyCheck2 = LedgerBook.Reconciliations.Sum(e => e.CalculatedSurplus) - recon.CalculatedSurplus;
             if (consistencyCheck1 != consistencyCheck2)
             {
                 throw new CorruptedLedgerBookException("Code Error: The previous dated entries have changed, this is not allowed. Data is corrupt.");

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -167,7 +167,7 @@ namespace BudgetAnalyser.Engine.Services
         }
 
         public LedgerEntryLine MonthEndReconciliation(
-            DateTime reconciliationDateIfFirstEver,
+            DateTime reconciliationStartDate,
             IEnumerable<BankBalance> balances,
             IBudgetCurrencyContext budgetContext,
             StatementModel statement,
@@ -196,7 +196,7 @@ namespace BudgetAnalyser.Engine.Services
             ReconciliationToDoList.Clear();
             Stopwatch stopWatch = Stopwatch.StartNew();
             this.logger.LogInfo(l => l.Format("Starting Ledger Book reconciliation {0}", DateTime.Now));
-            LedgerEntryLine recon = LedgerBook.Reconcile(reconciliationDateIfFirstEver, balances, budgetContext.Model, ReconciliationToDoList, statement, ignoreWarnings);
+            LedgerEntryLine recon = LedgerBook.Reconcile(reconciliationStartDate, balances, budgetContext.Model, ReconciliationToDoList, statement, ignoreWarnings);
             foreach (ToDoTask task in ReconciliationToDoList)
             {
                 this.logger.LogInfo(l => l.Format("TASK: {0} SystemGenerated:{1}", task.Description, task.SystemGenerated));

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -201,7 +201,7 @@ namespace BudgetAnalyser.Engine.Services
             {
                 this.logger.LogInfo(l => l.Format("TASK: {0} SystemGenerated:{1}", task.Description, task.SystemGenerated));
                 var transferTask = task as TransferTask;
-                if (transferTask != null)
+                if (transferTask != null && transferTask.SystemGenerated && transferTask.Reference.IsSomething())
                 {
                     this.transactionRuleService.CreateNewSingleUseRule(transferTask.BucketCode, null, new[] { transferTask.Reference }, null, transferTask.Amount, true);
                 }

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -53,6 +53,10 @@ namespace BudgetAnalyser.Engine.Services
         public ApplicationDataType DataType => ApplicationDataType.Ledger;
         public LedgerBook LedgerBook { get; private set; }
         public int LoadSequence => 50;
+
+        /// <summary>
+        /// The To Do List loaded from a persistent storage.
+        /// </summary>
         public ToDoCollection ReconciliationToDoList { get; private set; }
 
         public void CancelBalanceAdjustment(LedgerEntryLine entryLine, Guid transactionId)

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -230,6 +230,7 @@ namespace BudgetAnalyser.Engine.Services
                 var transferTask = task as TransferTask;
                 if (transferTask != null && transferTask.SystemGenerated && transferTask.Reference.IsSomething())
                 {
+                    this.logger.LogInfo(l => l.Format("TRANSFER-TASK detected- creating new single use rule. SystemGenerated:{1} Reference:{2}", task.Description, task.SystemGenerated, transferTask.Reference));
                     this.transactionRuleService.CreateNewSingleUseRule(transferTask.BucketCode, null, new[] { transferTask.Reference }, null, null, true);
                 }
             }

--- a/BudgetAnalyser.Engine/Services/LedgerService.cs
+++ b/BudgetAnalyser.Engine/Services/LedgerService.cs
@@ -203,7 +203,7 @@ namespace BudgetAnalyser.Engine.Services
                 var transferTask = task as TransferTask;
                 if (transferTask != null && transferTask.SystemGenerated && transferTask.Reference.IsSomething())
                 {
-                    this.transactionRuleService.CreateNewSingleUseRule(transferTask.BucketCode, null, new[] { transferTask.Reference }, null, null, true, 2);
+                    this.transactionRuleService.CreateNewSingleUseRule(transferTask.BucketCode, null, new[] { transferTask.Reference }, null, null, true);
                 }
             }
 

--- a/BudgetAnalyser.Engine/Services/TransactionManagerService.cs
+++ b/BudgetAnalyser.Engine/Services/TransactionManagerService.cs
@@ -64,7 +64,7 @@ namespace BudgetAnalyser.Engine.Services
                     return 0;
                 }
 
-                return this.transactions.Where(t => t.Amount < 0).Average(t => t.Amount);
+                return this.transactions.Where(t => t.Amount < 0).SafeAverage(t => t.Amount);
             }
         }
 

--- a/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
+++ b/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BudgetAnalyser.Engine.Annotations;
-using BudgetAnalyser.Engine.Budget;
 using BudgetAnalyser.Engine.Matching;
 using BudgetAnalyser.Engine.Persistence;
 using BudgetAnalyser.Engine.Statement;
@@ -66,45 +65,6 @@ namespace BudgetAnalyser.Engine.Services
         public ObservableCollection<MatchingRule> MatchingRules { get; }
         public ObservableCollection<RulesGroupedByBucket> MatchingRulesGroupedByBucket { get; }
 
-        public bool AddRule(MatchingRule ruleToAdd)
-        {
-            if (ruleToAdd == null)
-            {
-                throw new ArgumentNullException(nameof(ruleToAdd));
-            }
-            if (string.IsNullOrWhiteSpace(this.rulesStorageKey))
-            {
-                throw new InvalidOperationException("Unable to add a matching rule at this time, the service has not yet loaded a matching rule set.");
-            }
-
-            RulesGroupedByBucket existingGroup = MatchingRulesGroupedByBucket.FirstOrDefault(group => group.Bucket == ruleToAdd.Bucket);
-            if (existingGroup == null)
-            {
-                var addNewGroup = new RulesGroupedByBucket(ruleToAdd.Bucket, new[] { ruleToAdd });
-                MatchingRulesGroupedByBucket.Add(addNewGroup);
-                MatchingRules.Add(ruleToAdd);
-            }
-            else
-            {
-                if (existingGroup.Rules.Contains(ruleToAdd))
-                {
-                    this.logger.LogWarning(l => "Attempt to add new rule failed. Rule already exists in Grouped collection. " + ruleToAdd);
-                    return false;
-                }
-                existingGroup.Rules.Add(ruleToAdd);
-                if (MatchingRules.Contains(ruleToAdd))
-                {
-                    this.logger.LogWarning(l => "Attempt to add new rule failed. Rule already exists in main collection. " + ruleToAdd);
-                    return false;
-                }
-
-                MatchingRules.Add(ruleToAdd);
-            }
-
-            this.logger.LogInfo(_ => "Matching Rule Added: " + ruleToAdd);
-            return true;
-        }
-
         public void Close()
         {
             this.rulesStorageKey = null;
@@ -125,32 +85,18 @@ namespace BudgetAnalyser.Engine.Services
             await LoadAsync(applicationDatabase);
         }
 
-        public MatchingRule CreateNewRule(BudgetBucket bucket, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
+        public MatchingRule CreateNewRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
         {
-            if (bucket == null)
-            {
-                throw new ArgumentNullException(nameof(bucket));
-            }
+            MatchingRule rule = this.ruleFactory.CreateNewRule(bucketCode, description, references, transactionTypeName, amount, andMatching);
+            AddRule(rule);
+            return rule;
+        }
 
-            if (references == null)
-            {
-                throw new ArgumentNullException(nameof(references));
-            }
-
-            if (references.Length != 3)
-            {
-                throw new ArgumentException("The references array is expected to contain 3 elements.");
-            }
-
-            MatchingRule newRule = this.ruleFactory.CreateRule(bucket.Code);
-            newRule.Description = description;
-            newRule.Reference1 = references[0];
-            newRule.Reference2 = references[1];
-            newRule.Reference3 = references[2];
-            newRule.Amount = amount;
-            newRule.TransactionType = transactionTypeName;
-            newRule.And = andMatching;
-            return newRule;
+        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
+        {
+            SingleUseMatchingRule rule = this.ruleFactory.CreateNewSingleUseRule(bucketCode, description, references, transactionTypeName, amount, andMatching);
+            AddRule(rule);
+            return rule;
         }
 
         public bool IsRuleSimilar(MatchingRule rule, decimal amount, string description, string[] references, string transactionTypeName)
@@ -214,7 +160,12 @@ namespace BudgetAnalyser.Engine.Services
 
         public bool Match(IEnumerable<Transaction> transactions)
         {
-            return this.matchmaker.Match(transactions, MatchingRules);
+            var matchesMade = this.matchmaker.Match(transactions, MatchingRules);
+            foreach (var rule in MatchingRules.OfType<SingleUseMatchingRule>().ToList())
+            {
+                if (rule.MatchCount > 0) RemoveRule(rule);
+            }
+            return matchesMade;
         }
 
         public bool RemoveRule(MatchingRule ruleToRemove)
@@ -297,6 +248,44 @@ namespace BudgetAnalyser.Engine.Services
             }
 
             return operand1 == operand2;
+        }
+
+        private void AddRule(MatchingRule ruleToAdd)
+        {
+            if (ruleToAdd == null)
+            {
+                throw new ArgumentNullException(nameof(ruleToAdd));
+            }
+            if (string.IsNullOrWhiteSpace(this.rulesStorageKey))
+            {
+                throw new InvalidOperationException("Unable to add a matching rule at this time, the service has not yet loaded a matching rule set.");
+            }
+
+            RulesGroupedByBucket existingGroup = MatchingRulesGroupedByBucket.FirstOrDefault(group => group.Bucket == ruleToAdd.Bucket);
+            if (existingGroup == null)
+            {
+                var addNewGroup = new RulesGroupedByBucket(ruleToAdd.Bucket, new[] { ruleToAdd });
+                MatchingRulesGroupedByBucket.Add(addNewGroup);
+                MatchingRules.Add(ruleToAdd);
+            }
+            else
+            {
+                if (existingGroup.Rules.Contains(ruleToAdd))
+                {
+                    this.logger.LogWarning(l => "Attempt to add new rule failed. Rule already exists in Grouped collection. " + ruleToAdd);
+                    return;
+                }
+                existingGroup.Rules.Add(ruleToAdd);
+                if (MatchingRules.Contains(ruleToAdd))
+                {
+                    this.logger.LogWarning(l => "Attempt to add new rule failed. Rule already exists in main collection. " + ruleToAdd);
+                    return;
+                }
+
+                MatchingRules.Add(ruleToAdd);
+            }
+
+            this.logger.LogInfo(_ => "Matching Rule Added: " + ruleToAdd);
         }
     }
 }

--- a/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
+++ b/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
@@ -92,9 +92,9 @@ namespace BudgetAnalyser.Engine.Services
             return rule;
         }
 
-        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
+        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching, int lifetime = 1)
         {
-            SingleUseMatchingRule rule = this.ruleFactory.CreateNewSingleUseRule(bucketCode, description, references, transactionTypeName, amount, andMatching);
+            SingleUseMatchingRule rule = this.ruleFactory.CreateNewSingleUseRule(bucketCode, description, references, transactionTypeName, amount, andMatching, lifetime);
             AddRule(rule);
             return rule;
         }

--- a/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
+++ b/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
@@ -92,9 +92,9 @@ namespace BudgetAnalyser.Engine.Services
             return rule;
         }
 
-        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching, int lifetime = 1)
+        public SingleUseMatchingRule CreateNewSingleUseRule(string bucketCode, string description, string[] references, string transactionTypeName, decimal? amount, bool andMatching)
         {
-            SingleUseMatchingRule rule = this.ruleFactory.CreateNewSingleUseRule(bucketCode, description, references, transactionTypeName, amount, andMatching, lifetime);
+            SingleUseMatchingRule rule = this.ruleFactory.CreateNewSingleUseRule(bucketCode, description, references, transactionTypeName, amount, andMatching);
             AddRule(rule);
             return rule;
         }

--- a/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
+++ b/BudgetAnalyser.Engine/Services/TransactionRuleService.cs
@@ -195,9 +195,6 @@ namespace BudgetAnalyser.Engine.Services
 
         public async Task SaveAsync(IReadOnlyDictionary<ApplicationDataType, object> contextObjects)
         {
-            EventHandler<AdditionalInformationRequestedEventArgs> handler = Saving;
-            handler?.Invoke(this, new AdditionalInformationRequestedEventArgs());
-
             var messages = new StringBuilder();
             if (ValidateModel(messages))
             {
@@ -214,6 +211,8 @@ namespace BudgetAnalyser.Engine.Services
 
         public void SavePreview(IDictionary<ApplicationDataType, object> contextObjects)
         {
+            EventHandler<AdditionalInformationRequestedEventArgs> handler = Saving;
+            handler?.Invoke(this, new AdditionalInformationRequestedEventArgs());
         }
 
         public bool ValidateModel(StringBuilder messages)

--- a/BudgetAnalyser.Engine/Statement/TransactionGroupedByBucket.cs
+++ b/BudgetAnalyser.Engine/Statement/TransactionGroupedByBucket.cs
@@ -41,7 +41,7 @@ namespace BudgetAnalyser.Engine.Statement
                 IEnumerable<Transaction> query = Transactions.Where(t => t.Amount < 0).ToList();
                 if (query.Any())
                 {
-                    return query.Average(t => t.Amount);
+                    return query.SafeAverage(t => t.Amount);
                 }
 
                 return 0;

--- a/BudgetAnalyser.UnitTest/AutoMapperConfigurationTest.cs
+++ b/BudgetAnalyser.UnitTest/AutoMapperConfigurationTest.cs
@@ -2,6 +2,7 @@
 using BudgetAnalyser.Engine;
 using BudgetAnalyser.Engine.Account;
 using BudgetAnalyser.Engine.Budget.Data;
+using BudgetAnalyser.Engine.Ledger;
 using BudgetAnalyser.Engine.Ledger.Data;
 using BudgetAnalyser.Engine.Matching;
 using BudgetAnalyser.Engine.Matching.Data;
@@ -31,7 +32,12 @@ namespace BudgetAnalyser.UnitTest
                             new ILocalAutoMapperConfiguration[]
                             {
                                 new BudgetAutoMapperConfiguration(new BudgetBucketFactory(), new BucketBucketRepoAlwaysFind(), new FakeLogger()),
-                                new LedgerAutoMapperConfiguration(new LedgerTransactionFactory(), new InMemoryAccountTypeRepository(), new BucketBucketRepoAlwaysFind(), new FakeLogger()),
+                                new LedgerAutoMapperConfiguration(
+                                    new LedgerTransactionFactory(), 
+                                    new InMemoryAccountTypeRepository(), 
+                                    new BucketBucketRepoAlwaysFind(), 
+                                    new FakeLogger(), 
+                                    new LedgerBookFactory(new ReconciliationBuilder(new FakeLogger()), new FakeLogger())),
                                 new MatchingAutoMapperConfiguration(new MatchingRuleFactory(new BucketBucketRepoAlwaysFind())),
                                 new StatementAutoMapperConfiguration(new InMemoryTransactionTypeRepository(), new InMemoryAccountTypeRepository(), new BucketBucketRepoAlwaysFind(), new FakeLogger()),
                                 new ApplicationAutoMapperConfiguration()

--- a/BudgetAnalyser.UnitTest/BudgetAnalyser.UnitTest.csproj
+++ b/BudgetAnalyser.UnitTest/BudgetAnalyser.UnitTest.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Services\TransactionManagerServiceTest.cs" />
     <Compile Include="Services\ApplicationDatabaseServiceTest.cs" />
     <Compile Include="Services\TransactionRuleServiceTest.cs" />
+    <Compile Include="Services\LedgerServiceTest.cs" />
     <Compile Include="Statement\AnzVisaStatementImporterV1Test.cs" />
     <Compile Include="Statement\AnzAccountStatementImporterV1Test.cs" />
     <Compile Include="Statement\BankImportUtilitiesTest.cs" />
@@ -259,6 +260,7 @@
     <Compile Include="TestHarness\AnzVisaStatementImporterV1TestHarness.cs" />
     <Compile Include="TestHarness\AnzAccountStatementImporterV1TestHarness.cs" />
     <Compile Include="TestHarness\BankImportUtilitiesTestHarness.cs" />
+    <Compile Include="TestHarness\LedgerBookTestHarness.cs" />
     <Compile Include="TestHarness\LoggerTestHarness.cs" />
     <Compile Include="TestHarness\BucketBucketRepoAlwaysFind.cs" />
     <Compile Include="TestHarness\BudgetBucketTestHarness.cs" />

--- a/BudgetAnalyser.UnitTest/BudgetAnalyser.UnitTest.csproj
+++ b/BudgetAnalyser.UnitTest/BudgetAnalyser.UnitTest.csproj
@@ -107,7 +107,9 @@
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
@@ -220,6 +222,7 @@
     <Compile Include="Services\StatementModelTestHarness.cs" />
     <Compile Include="Services\TransactionManagerServiceTest.cs" />
     <Compile Include="Services\ApplicationDatabaseServiceTest.cs" />
+    <Compile Include="Services\TransactionRuleServiceTest.cs" />
     <Compile Include="Statement\AnzVisaStatementImporterV1Test.cs" />
     <Compile Include="Statement\AnzAccountStatementImporterV1Test.cs" />
     <Compile Include="Statement\BankImportUtilitiesTest.cs" />

--- a/BudgetAnalyser.UnitTest/Ledger/LedgerBook_GeneralTest.cs
+++ b/BudgetAnalyser.UnitTest/Ledger/LedgerBook_GeneralTest.cs
@@ -16,11 +16,24 @@ namespace BudgetAnalyser.UnitTest.Ledger
     {
         private static readonly IEnumerable<BankBalance> NextReconcileBankBalance = new[] { new BankBalance(StatementModelTestData.ChequeAccount, 1850.5M) };
         private static readonly DateTime NextReconcileDate = new DateTime(2013, 09, 15);
+        private BudgetModel testDataBudget;
+        private StatementModel testDataStatement;
+        private ToDoCollection testDataToDoList;
+        private LedgerBook subject;
+
+        [TestInitialize]
+        public void TestInitialise()
+        {
+            this.testDataStatement = StatementModelTestData.TestData1();
+            this.testDataToDoList = new ToDoCollection();
+            this.testDataBudget = BudgetModelTestData.CreateTestData1();
+            this.subject = LedgerBookTestData.TestData1();
+        }
 
         [TestMethod]
         public void UnlockMostRecentLineShouldNotThrowIfBookIsEmpty()
         {
-            var subject = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
+            this.subject = new LedgerBook(new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Foo",
                 Modified = new DateTime(2011, 12, 4),
@@ -34,7 +47,6 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UnlockMostRecentLineShouldReturnMostRecentLine()
         {
-            LedgerBook subject = ArrangeAndAct();
             LedgerEntryLine result = subject.UnlockMostRecentLine();
             LedgerEntryLine expectedLine = subject.Reconciliations.OrderByDescending(e => e.Date).First();
 
@@ -44,7 +56,6 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UnlockMostRecentLineShouldUnlockMostRecentLine()
         {
-            LedgerBook subject = ArrangeAndAct();
             LedgerEntryLine result = subject.UnlockMostRecentLine();
 
             Assert.IsTrue(result.IsNew);
@@ -53,20 +64,16 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_AddAdjustment_Output()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = Act(this.subject, this.testDataBudget);
             result.BalanceAdjustment(101M, "foo dar far");
 
-            book.Output();
+            this.subject.Output();
         }
 
         [TestMethod]
         public void UsingTestData1_AddAdjustment_ShouldAddToAdjustmentCollection()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = Act(this.subject, this.testDataBudget);
             result.BalanceAdjustment(101M, "foo dar far");
 
             Assert.AreEqual(1, result.BankBalanceAdjustments.Count());
@@ -75,9 +82,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_AddAdjustment_ShouldAffectLedgerBalance()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = Act(this.subject, this.testDataBudget);
             result.BalanceAdjustment(-101M, "foo dar far");
 
             Assert.AreEqual(1749.50M, result.LedgerBalance);
@@ -86,25 +91,19 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_AddTransactionShouldEffectEntryBalance()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            LedgerEntryLine entryLine = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine entryLine = Act(this.subject, this.testDataBudget);
             var newTransaction = new CreditLedgerTransaction { Amount = -100 };
             LedgerEntry entry = entryLine.Entries.First();
             entry.AddTransaction(newTransaction);
 
-            book.Output();
+            this.subject.Output();
             Assert.AreEqual(20, entry.Balance);
         }
 
         [TestMethod]
         public void UsingTestData1_AddTransactionShouldEffectEntryNetAmount()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            LedgerEntryLine entryLine = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine entryLine = Act(this.subject, this.testDataBudget);
             var newTransaction = new CreditLedgerTransaction { Amount = -100 };
             LedgerEntry entry = entryLine.Entries.First();
             entry.AddTransaction(newTransaction);
@@ -115,10 +114,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_RemoveTransactionShouldEffectEntryBalance()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            LedgerEntryLine entryLine = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine entryLine = Act(this.subject, this.testDataBudget);
             LedgerEntry entry = entryLine.Entries.First();
             entry.RemoveTransaction(entry.Transactions.First(t => t is CreditLedgerTransaction).Id);
 
@@ -128,10 +124,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_RemoveTransactionShouldEffectEntryNetAmount()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            LedgerEntryLine entryLine = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine entryLine = Act(this.subject, this.testDataBudget);
             LedgerEntry entry = entryLine.Entries.First();
             entry.RemoveTransaction(entry.Transactions.First(t => t is CreditLedgerTransaction).Id);
 
@@ -141,24 +134,18 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_RemoveTransactionShouldGiveSurplus1558()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            LedgerEntryLine entryLine = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine entryLine = Act(this.subject, this.testDataBudget);
             LedgerEntry entry = entryLine.Entries.First();
             entry.RemoveTransaction(entry.Transactions.First(t => t is CreditLedgerTransaction).Id);
 
-            book.Output();
+            this.subject.Output();
             Assert.AreEqual(1558.47M, entryLine.CalculatedSurplus);
         }
 
         [TestMethod]
         public void UsingTestData1_UpdateRemarks_ShouldSetRemarks()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = Act(this.subject, this.testDataBudget);
             result.UpdateRemarks("Foo bar");
 
             Assert.AreEqual("Foo bar", result.Remarks);
@@ -171,9 +158,9 @@ namespace BudgetAnalyser.UnitTest.Ledger
             book.Output();
         }
 
-        private LedgerBook ArrangeAndAct()
+        private LedgerEntryLine Act(LedgerBook book, BudgetModel budget)
         {
-            return LedgerBookTestData.TestData1();
+            return book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, this.testDataToDoList, this.testDataStatement);
         }
     }
 }

--- a/BudgetAnalyser.UnitTest/Ledger/LedgerBook_GeneralTest.cs
+++ b/BudgetAnalyser.UnitTest/Ledger/LedgerBook_GeneralTest.cs
@@ -20,7 +20,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UnlockMostRecentLineShouldNotThrowIfBookIsEmpty()
         {
-            var subject = new LedgerBook(new FakeLogger())
+            var subject = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Foo",
                 Modified = new DateTime(2011, 12, 4),

--- a/BudgetAnalyser.UnitTest/Ledger/LedgerBook_ReconcileTest.cs
+++ b/BudgetAnalyser.UnitTest/Ledger/LedgerBook_ReconcileTest.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.Remoting;
 using BudgetAnalyser.Engine;
 using BudgetAnalyser.Engine.Budget;
 using BudgetAnalyser.Engine.Ledger;
@@ -20,8 +19,11 @@ namespace BudgetAnalyser.UnitTest.Ledger
     public class LedgerBook_ReconcileTest
     {
         private static readonly IEnumerable<BankBalance> NextReconcileBankBalance = new[] { new BankBalance(StatementModelTestData.ChequeAccount, 1850.5M) };
-        private static readonly DateTime ReconcileStartDate = new DateTime(2013, 09, 15);
-        private readonly ToDoCollection toDoCollection = new ToDoCollection();
+        private static readonly DateTime ReconcileDate = new DateTime(2013, 09, 15);
+        private LedgerBook subject;
+        private BudgetModel testDataBudget;
+        private StatementModel testDataStatement;
+        private ToDoCollection testDataToDoList;
 
         [TestMethod]
         public void DuplicateReferenceNumberTest()
@@ -40,44 +42,31 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void OutputTestData5()
         {
-            LedgerBook testData = LedgerBookTestData.TestData5();
-            testData.Output(true);
+            LedgerBookTestData.TestData5().Output(true);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void UsingInvalidLedgerBook_Reconcile_ShouldThrow()
+        [TestInitialize]
+        public void TestInitialise()
         {
-            var subject = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
-            {
-                Name = "Foo",
-                Modified = new DateTime(2012, 02, 29),
-                FileName = ""
-            };
-
-            subject.Reconcile(
-                new DateTime(2012, 02, 20),
-                new[] { new BankBalance(StatementModelTestData.ChequeAccount, 2050M) },
-                BudgetModelTestData.CreateTestData1(),
-                statement: StatementModelTestData.TestData1());
+            this.testDataBudget = BudgetModelTestData.CreateTestData1();
+            this.testDataStatement = StatementModelTestData.TestData1();
+            this.testDataToDoList = new ToDoCollection();
+            this.subject = LedgerBookTestData.TestData1();
         }
 
         [TestMethod]
         public void UsingTestData1_AddLedger_ShouldAddToLedgersCollection()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            book.AddLedger(new SavedUpForExpenseBucket("FOO", "Foo bar"), null);
+            this.subject.AddLedger(new SavedUpForExpenseBucket("FOO", "Foo bar"), null);
 
-            Assert.IsTrue(book.Ledgers.Any(l => l.BudgetBucket.Code == "FOO"));
+            Assert.IsTrue(this.subject.Ledgers.Any(l => l.BudgetBucket.Code == "FOO"));
         }
 
         [TestMethod]
         public void UsingTestData1_AddLedger_ShouldBeIncludedInNextReconcile()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            book.AddLedger(new SavedUpForExpenseBucket("FOO", "Foo bar"), null);
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
+            this.subject.AddLedger(new SavedUpForExpenseBucket("FOO", "Foo bar"), null);
+            LedgerEntryLine result = Act();
 
             Assert.IsTrue(result.Entries.Any(e => e.LedgerBucket.BudgetBucket.Code == "FOO"));
         }
@@ -85,66 +74,45 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_Reconcile_Output()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
-
-            book.Output();
+            Act();
+            this.subject.Output();
         }
 
         [TestMethod]
         public void UsingTestData1_Reconcile_ShouldInsertLastestInFront()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
-
-            Assert.AreEqual(result, book.Reconciliations.First());
+            LedgerEntryLine result = Act();
+            Assert.AreEqual(result, this.subject.Reconciliations.First());
         }
 
         [TestMethod]
-        public void UsingTestData1_Reconcile_ShouldResultIn1558()
+        public void UsingTestData1_Reconcile_ShouldResultIn1613()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
-            book.Output(true);
-            Assert.AreEqual(1558.47M, result.CalculatedSurplus);
+            LedgerEntryLine result = Act();
+            this.subject.Output(true);
+            Assert.AreEqual(1613.47M, result.CalculatedSurplus);
         }
 
         [TestMethod]
         public void UsingTestData1_Reconcile_ShouldResultIn4Lines()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
+            LedgerEntryLine result = Act();
 
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
-
-            Assert.AreEqual(4, book.Reconciliations.Count());
+            Assert.AreEqual(4, this.subject.Reconciliations.Count());
         }
 
         [TestMethod]
         public void UsingTestData1_Reconcile_WithStatementOutput()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
-            book.Output(true);
+            Act();
+            this.subject.Output(true);
         }
 
         [TestMethod]
         [Description("This test overdraws the Hair ledger and tests to make sure the reconciliation process compensates and leaves it with a balance equal to the monthly payment amount.")]
         public void UsingTestData1_Reconcile_WithStatementSavedUpForHairLedgerShouldHaveBalance55()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            List<Transaction> additionalTransactions = statement.AllTransactions.ToList();
+            List<Transaction> additionalTransactions = this.testDataStatement.AllTransactions.ToList();
 
             additionalTransactions.Add(
                 new Transaction
@@ -154,10 +122,10 @@ namespace BudgetAnalyser.UnitTest.Ledger
                     BudgetBucket = additionalTransactions.First(t => t.BudgetBucket.Code == TestDataConstants.HairBucketCode).BudgetBucket,
                     Date = new DateTime(2013, 09, 13)
                 });
-            statement.LoadTransactions(additionalTransactions);
+            this.testDataStatement.LoadTransactions(additionalTransactions);
 
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
-            book.Output(true);
+            LedgerEntryLine result = Act();
+            this.subject.Output(true);
 
             Assert.AreEqual(55M, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.HairBucketCode).Balance);
             Assert.IsTrue(result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.HairBucketCode).NetAmount < 0);
@@ -166,129 +134,56 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [TestMethod]
         public void UsingTestData1_Reconcile_WithStatementShouldHave2HairTransactions()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            book.Output();
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
+            this.subject.Output();
+            LedgerEntryLine result = Act();
             Assert.AreEqual(2, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.HairBucketCode).Transactions.Count());
         }
 
         [TestMethod]
         public void UsingTestData1_Reconcile_WithStatementShouldHave3PowerTransactions()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            book.Output();
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
-            book.Output(true);
+            this.subject.Output();
+            LedgerEntryLine result = Act();
+            this.subject.Output(true);
             Assert.AreEqual(3, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.PowerBucketCode).Transactions.Count());
         }
 
         [TestMethod]
         public void UsingTestData1_Reconcile_WithStatementShouldHaveSurplus1613()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
-            book.Output(true);
+            LedgerEntryLine result = Act();
+            this.subject.Output(true);
             Assert.AreEqual(1613.47M, result.CalculatedSurplus);
         }
 
         [TestMethod]
         public void UsingTestData1_Reconcile_WithStatementSpentMonthlyLedgerShouldSupplementShortfall()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
-            book.Output(true);
-
+            LedgerEntryLine result = Act();
+            this.subject.Output(true);
             Assert.AreEqual(64.71M, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.PhoneBucketCode).Balance);
         }
 
         [TestMethod]
         public void UsingTestData1_Reconcile_WithStatementWithBalanceAdjustment599ShouldHaveSurplus1014()
         {
-            LedgerBook book = LedgerBookTestData.TestData1();
-            BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-
-            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = Act();
             result.BalanceAdjustment(-599M, "Visa pmt not yet in statement");
-            book.Output(true);
+            this.subject.Output(true);
             Assert.AreEqual(1014.47M, result.CalculatedSurplus);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ValidationWarningException))]
-        public void UsingTestData1AndNoStatementModelTransactions_Reconcile_ShouldThrow()
-        {
-            LedgerBook subject = LedgerBookTestData.TestData1();
-
-            subject.Reconcile(
-                new DateTime(2013, 10, 15),
-                new[] { new BankBalance(StatementModelTestData.ChequeAccount, 2050M) },
-                BudgetModelTestData.CreateTestData1(),
-                statement: StatementModelTestData.TestData1());
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ValidationWarningException))]
-        public void UsingTestData1AndUnclassifiedTransactions_Reconcile_ShouldThrow()
-        {
-            LedgerBook subject = LedgerBookTestData.TestData1();
-            StatementModel statement = StatementModelTestData.TestData1();
-            Transaction aTransaction = statement.AllTransactions.First();
-            PrivateAccessor.SetField(aTransaction, "budgetBucket", null);
-
-            subject.Reconcile(
-                new DateTime(2013, 9, 15),
-                new[] { new BankBalance(StatementModelTestData.ChequeAccount, 2050M) },
-                BudgetModelTestData.CreateTestData1(),
-                statement: statement);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void UsingTestData1WithDateEqualToExistingLine_Reconcile_ShouldThrow()
-        {
-            LedgerBook subject = LedgerBookTestData.TestData1();
-
-            subject.Reconcile(
-                new DateTime(2013, 08, 15),
-                new[] { new BankBalance(StatementModelTestData.ChequeAccount, 2050M) },
-                BudgetModelTestData.CreateTestData1(),
-                statement: StatementModelTestData.TestData1());
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void UsingTestData1WithDateLessThanExistingLine_Reconcile_ShouldThrow()
-        {
-            LedgerBook subject = LedgerBookTestData.TestData1();
-
-            subject.Reconcile(
-                new DateTime(2013, 07, 15),
-                new[] { new BankBalance(StatementModelTestData.ChequeAccount, 2050M) },
-                BudgetModelTestData.CreateTestData1(),
-                statement: StatementModelTestData.TestData1());
         }
 
         [TestMethod]
         public void UsingTestData5_Reconcile_ShouldAutoMatchTransactionsAndLinkToStatementTransaction()
         {
             // The automatched credit ledger transaction from last month should be linked to the statement transaction.
-            StatementModel statementModelTestData = StatementModelTestData.TestData5();
-            List<Transaction> statementTransactions = statementModelTestData.AllTransactions.Where(t => t.Reference1 == "agkT9kC").ToList();
+            this.testDataStatement = StatementModelTestData.TestData5();
+            List<Transaction> statementTransactions = this.testDataStatement.AllTransactions.Where(t => t.Reference1 == "agkT9kC").ToList();
             Debug.Assert(statementTransactions.Count() == 2);
 
-            LedgerBook book = ActOnTestData5(statementModelTestData);
+            ActOnTestData5(this.testDataStatement);
             LedgerEntry previousMonthLine =
-                book.Reconciliations.Single(line => line.Date == new DateTime(2013, 08, 15)).Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket);
+                this.subject.Reconciliations.Single(line => line.Date == new DateTime(2013, 08, 15)).Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket);
             BudgetCreditLedgerTransaction previousLedgerTxn = previousMonthLine.Transactions.OfType<BudgetCreditLedgerTransaction>().Single();
 
             // Assert last month's ledger transaction has been linked to the credit 16/8/13
@@ -299,26 +194,26 @@ namespace BudgetAnalyser.UnitTest.Ledger
         public void UsingTestData5_Reconcile_ShouldAutoMatchTransactionsAndResultIn1InsHomeTransaction()
         {
             // Two transactions should be removed as they are automatched to the previous month.
-            LedgerBook book = ActOnTestData5();
+            ActOnTestData5();
 
-            Assert.AreEqual(1, book.Reconciliations.First().Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket).Transactions.Count());
+            Assert.AreEqual(1, this.subject.Reconciliations.First().Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket).Transactions.Count());
             // Assert last month's ledger transaction has been linked to the credit 16/8/13
         }
 
         [TestMethod]
         public void UsingTestData5_Reconcile_ShouldAutoMatchTransactionsAndResultInInsHomeBalance1200()
         {
-            LedgerBook book = ActOnTestData5();
-            Assert.AreEqual(1200M, book.Reconciliations.First().Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket).Balance);
+            ActOnTestData5();
+            Assert.AreEqual(1200M, this.subject.Reconciliations.First().Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket).Balance);
         }
 
         [TestMethod]
         public void UsingTestData5_Reconcile_ShouldAutoMatchTransactionsAndUpdateLedgerAutoMatchRefSoItIsNotAutoMatchedAgain()
         {
             // Two transactions should be removed as they are automatched to the previous month.
-            LedgerBook book = ActOnTestData5();
+            ActOnTestData5();
             LedgerEntry previousMonthLine =
-                book.Reconciliations.Single(line => line.Date == new DateTime(2013, 08, 15)).Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket);
+                this.subject.Reconciliations.Single(line => line.Date == new DateTime(2013, 08, 15)).Entries.Single(e => e.LedgerBucket.BudgetBucket == StatementModelTestData.InsHomeBucket);
             BudgetCreditLedgerTransaction previousLedgerTxn = previousMonthLine.Transactions.OfType<BudgetCreditLedgerTransaction>().Single();
 
             Console.WriteLine(previousLedgerTxn.AutoMatchingReference);
@@ -329,42 +224,30 @@ namespace BudgetAnalyser.UnitTest.Ledger
         public void UsingTestData5_Reconcile_ShouldCreateToDoEntries()
         {
             ActOnTestData5();
-            
-            Assert.AreEqual(1, this.toDoCollection.OfType<TransferTask>().Count(t => t.Reference.IsSomething() && t.BucketCode.IsSomething()));
+
+            Assert.AreEqual(1, this.testDataToDoList.OfType<TransferTask>().Count(t => t.Reference.IsSomething() && t.BucketCode.IsSomething()));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ValidationWarningException))]
-        public void UsingTestData5_Reconcile_ShouldThrowWhenAutoMatchingTransactionAreMissingFromStatement()
+        private LedgerEntryLine Act(DateTime? reconciliationDate = null, IEnumerable<BankBalance> bankBalances = null)
         {
-            LedgerBook book = ActOnTestData5(StatementModelTestData.TestData4());
-            Assert.Fail();
+            return this.subject.Reconcile(reconciliationDate ?? ReconcileDate, bankBalances ?? NextReconcileBankBalance, this.testDataBudget, this.testDataToDoList, this.testDataStatement);
         }
 
-        private LedgerBook ActOnTestData5(StatementModel statementTestData = null)
+        private void ActOnTestData5(StatementModel statementModelTestData = null)
         {
-            LedgerBook book = LedgerBookTestData.TestData5();
-            BudgetModel budget = BudgetModelTestData.CreateTestData5();
-            if (statementTestData == null)
-            {
-                statementTestData = StatementModelTestData.TestData5();
-            }
+            this.subject = LedgerBookTestData.TestData5();
+            this.testDataBudget = BudgetModelTestData.CreateTestData5();
+            this.testDataStatement = statementModelTestData ?? StatementModelTestData.TestData5();
 
             Console.WriteLine("********************** BEFORE RUNNING RECONCILIATION *******************************");
-            statementTestData.Output(ReconcileStartDate.AddMonths(-1));
-            book.Output(true);
+            this.testDataStatement.Output(ReconcileDate.AddMonths(-1));
+            this.subject.Output(true);
 
-            book.Reconcile(
-                ReconcileStartDate,
-                new[] { new BankBalance(StatementModelTestData.ChequeAccount, 1850.5M), new BankBalance(StatementModelTestData.SavingsAccount, 1200M) },
-                budget,
-                statement: statementTestData,
-                toDoList: this.toDoCollection);
+            Act(bankBalances: new[] { new BankBalance(StatementModelTestData.ChequeAccount, 1850.5M), new BankBalance(StatementModelTestData.SavingsAccount, 1200M) });
 
             Console.WriteLine();
             Console.WriteLine("********************** AFTER RUNNING RECONCILIATION *******************************");
-            book.Output(true);
-            return book;
+            this.subject.Output(true);
         }
     }
 

--- a/BudgetAnalyser.UnitTest/Ledger/LedgerBook_ReconcileTest.cs
+++ b/BudgetAnalyser.UnitTest/Ledger/LedgerBook_ReconcileTest.cs
@@ -46,7 +46,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
         [ExpectedException(typeof(InvalidOperationException))]
         public void UsingInvalidLedgerBook_Reconcile_ShouldThrow()
         {
-            var subject = new LedgerBook(new FakeLogger())
+            var subject = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Foo",
                 Modified = new DateTime(2012, 02, 29),

--- a/BudgetAnalyser.UnitTest/Ledger/LedgerBook_ReconcileTest.cs
+++ b/BudgetAnalyser.UnitTest/Ledger/LedgerBook_ReconcileTest.cs
@@ -20,8 +20,8 @@ namespace BudgetAnalyser.UnitTest.Ledger
     public class LedgerBook_ReconcileTest
     {
         private static readonly IEnumerable<BankBalance> NextReconcileBankBalance = new[] { new BankBalance(StatementModelTestData.ChequeAccount, 1850.5M) };
-        private static readonly DateTime NextReconcileDate = new DateTime(2013, 09, 15);
-        private ToDoCollection toDoCollection = new ToDoCollection();
+        private static readonly DateTime ReconcileStartDate = new DateTime(2013, 09, 15);
+        private readonly ToDoCollection toDoCollection = new ToDoCollection();
 
         [TestMethod]
         public void DuplicateReferenceNumberTest()
@@ -77,7 +77,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             LedgerBook book = LedgerBookTestData.TestData1();
             book.AddLedger(new SavedUpForExpenseBucket("FOO", "Foo bar"), null);
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
 
             Assert.IsTrue(result.Entries.Any(e => e.LedgerBucket.BudgetBucket.Code == "FOO"));
         }
@@ -88,7 +88,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             LedgerBook book = LedgerBookTestData.TestData1();
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
 
             book.Output();
         }
@@ -99,7 +99,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             LedgerBook book = LedgerBookTestData.TestData1();
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
 
             Assert.AreEqual(result, book.Reconciliations.First());
         }
@@ -110,7 +110,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             LedgerBook book = LedgerBookTestData.TestData1();
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
             book.Output(true);
             Assert.AreEqual(1558.47M, result.CalculatedSurplus);
         }
@@ -121,7 +121,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             LedgerBook book = LedgerBookTestData.TestData1();
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget);
 
             Assert.AreEqual(4, book.Reconciliations.Count());
         }
@@ -133,7 +133,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
             StatementModel statement = StatementModelTestData.TestData1();
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
             book.Output(true);
         }
 
@@ -156,7 +156,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
                 });
             statement.LoadTransactions(additionalTransactions);
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
             book.Output(true);
 
             Assert.AreEqual(55M, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.HairBucketCode).Balance);
@@ -170,7 +170,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
             StatementModel statement = StatementModelTestData.TestData1();
             book.Output();
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
             Assert.AreEqual(2, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.HairBucketCode).Transactions.Count());
         }
 
@@ -181,7 +181,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
             StatementModel statement = StatementModelTestData.TestData1();
             book.Output();
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
             book.Output(true);
             Assert.AreEqual(3, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.PowerBucketCode).Transactions.Count());
         }
@@ -192,7 +192,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             LedgerBook book = LedgerBookTestData.TestData1();
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
             StatementModel statement = StatementModelTestData.TestData1();
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
             book.Output(true);
             Assert.AreEqual(1613.47M, result.CalculatedSurplus);
         }
@@ -204,7 +204,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
             StatementModel statement = StatementModelTestData.TestData1();
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
             book.Output(true);
 
             Assert.AreEqual(64.71M, result.Entries.Single(e => e.LedgerBucket.BudgetBucket.Code == TestDataConstants.PhoneBucketCode).Balance);
@@ -217,7 +217,7 @@ namespace BudgetAnalyser.UnitTest.Ledger
             BudgetModel budget = BudgetModelTestData.CreateTestData1();
             StatementModel statement = StatementModelTestData.TestData1();
 
-            LedgerEntryLine result = book.Reconcile(NextReconcileDate, NextReconcileBankBalance, budget, statement: statement);
+            LedgerEntryLine result = book.Reconcile(ReconcileStartDate, NextReconcileBankBalance, budget, statement: statement);
             result.BalanceAdjustment(-599M, "Visa pmt not yet in statement");
             book.Output(true);
             Assert.AreEqual(1014.47M, result.CalculatedSurplus);
@@ -351,11 +351,11 @@ namespace BudgetAnalyser.UnitTest.Ledger
             }
 
             Console.WriteLine("********************** BEFORE RUNNING RECONCILIATION *******************************");
-            statementTestData.Output(NextReconcileDate.AddMonths(-1));
+            statementTestData.Output(ReconcileStartDate.AddMonths(-1));
             book.Output(true);
 
             book.Reconcile(
-                NextReconcileDate,
+                ReconcileStartDate,
                 new[] { new BankBalance(StatementModelTestData.ChequeAccount, 1850.5M), new BankBalance(StatementModelTestData.SavingsAccount, 1200M) },
                 budget,
                 statement: statementTestData,

--- a/BudgetAnalyser.UnitTest/Matching/DataMatchingRuleToMatchingRuleMapperTest.cs
+++ b/BudgetAnalyser.UnitTest/Matching/DataMatchingRuleToMatchingRuleMapperTest.cs
@@ -57,7 +57,7 @@ namespace BudgetAnalyser.UnitTest.Matching
         public void NumberOfDataMatchingRulePropertiesShouldBe12()
         {
             int dataProperties = typeof(MatchingRule).CountProperties();
-            Assert.AreEqual(12, dataProperties);
+            Assert.AreEqual(13, dataProperties);
         }
 
         [TestMethod]

--- a/BudgetAnalyser.UnitTest/MetaTest.cs
+++ b/BudgetAnalyser.UnitTest/MetaTest.cs
@@ -8,7 +8,7 @@ namespace BudgetAnalyser.UnitTest
     [TestClass]
     public class MetaTest
     {
-        private const int ExpectedMinimumTests = 794;
+        private const int ExpectedMinimumTests = 809;
 
         [TestMethod]
         public void ListAllTests()

--- a/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
@@ -27,8 +27,26 @@ namespace BudgetAnalyser.UnitTest.Services
         public void MonthEndReconciliation_ShouldCreateSingleUseMatchingRulesForTransferToDos()
         {
             var testTodoList = new ToDoCollection();
-            PrivateAccessor.SetProperty(this.subject, nameof(this.subject.LedgerBook), new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object));
+
+            PrivateAccessor.SetProperty(
+                this.subject, 
+                nameof(this.subject.LedgerBook), 
+                LedgerBookTestData.TestData5(() => new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object)));
+
+            ((LedgerBookTestHarness)this.subject.LedgerBook).ReconcileOverride = () =>
+            {
+                testTodoList.Add(
+                    new TransferTask(string.Empty, true, true)
+                    {
+                        Reference = "sjghsh",
+                        Amount = 12.22M,
+                        BucketCode = StatementModelTestData.CarMtcBucket.Code,
+                    });
+                return new LedgerEntryLine(ReconcileStartDate, new List<BankBalance>());
+            };
+
             PrivateAccessor.SetProperty(this.subject, nameof(this.subject.ReconciliationToDoList), testTodoList);
+
             this.mockRuleService.Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), true))
                 .Returns(new SingleUseMatchingRule(this.bucketRepo));
 
@@ -36,16 +54,16 @@ namespace BudgetAnalyser.UnitTest.Services
                 ReconcileStartDate,
                 new List<BankBalance>(),
                 new BudgetCurrencyContext(this.budgetTestData, this.budgetTestData.CurrentActiveBudget),
-                StatementModelTestData.TestData1());
+                StatementModelTestData.TestData5());
 
-            this.mockRuleService.Verify();
+            this.mockRuleService.VerifyAll();
         }
 
         [TestInitialize]
         public void TestIntialise()
         {
             this.mockLedgerRepo = new Mock<ILedgerBookRepository>();
-            this.mockRuleService = new Mock<ITransactionRuleService>();
+            this.mockRuleService = new Mock<ITransactionRuleService>(MockBehavior.Strict);
             this.bucketRepo = new BucketBucketRepoAlwaysFind();
             this.subject = new LedgerService(this.mockLedgerRepo.Object, new InMemoryAccountTypeRepository(), new FakeLogger(), this.mockRuleService.Object);
         }

--- a/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using BudgetAnalyser.Engine;
 using BudgetAnalyser.Engine.Account;
 using BudgetAnalyser.Engine.Budget;
 using BudgetAnalyser.Engine.Ledger;
 using BudgetAnalyser.Engine.Matching;
 using BudgetAnalyser.Engine.Services;
+using BudgetAnalyser.Engine.Statement;
+using BudgetAnalyser.UnitTest.Helper;
 using BudgetAnalyser.UnitTest.TestData;
 using BudgetAnalyser.UnitTest.TestHarness;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -16,46 +20,43 @@ namespace BudgetAnalyser.UnitTest.Services
     [TestClass]
     public class LedgerServiceTest
     {
-        private static readonly DateTime ReconcileStartDate = new DateTime(2013, 09, 15);
-        private readonly BudgetCollection budgetTestData = BudgetModelTestData.CreateCollectionWith1And2();
+        private static readonly DateTime ReconcileDate = new DateTime(2013, 09, 15);
+        private static readonly IEnumerable<BankBalance> NextReconcileBankBalance = new[] { new BankBalance(StatementModelTestData.ChequeAccount, 2050M) };
+
         private IBudgetBucketRepository bucketRepo;
         private Mock<ILedgerBookRepository> mockLedgerRepo;
         private Mock<ITransactionRuleService> mockRuleService;
         private LedgerService subject;
+        private IBudgetCurrencyContext testDataBudgetContext;
+        private BudgetCollection testDataBudgets;
+        private StatementModel testDataStatement;
+        private ToDoCollection testDataToDoList;
+        private Mock<IReconciliationConsistency> mockReconciliationConsistency;
 
         [TestMethod]
         public void MonthEndReconciliation_ShouldCreateSingleUseMatchingRulesForTransferToDos()
         {
-            var testTodoList = new ToDoCollection();
-
-            PrivateAccessor.SetProperty(
-                this.subject, 
-                nameof(this.subject.LedgerBook), 
-                LedgerBookTestData.TestData5(() => new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object)));
-
+            // Artifically create a transfer to do task when the reconciliation method is invoked on the LedgerBook.
+            // Remember: the subject here is the LedgerService not the LedgerBook.
             ((LedgerBookTestHarness)this.subject.LedgerBook).ReconcileOverride = () =>
             {
-                testTodoList.Add(
+                this.testDataToDoList.Add(
                     new TransferTask(string.Empty, true, true)
                     {
                         Reference = "sjghsh",
                         Amount = 12.22M,
-                        BucketCode = StatementModelTestData.CarMtcBucket.Code,
+                        BucketCode = StatementModelTestData.CarMtcBucket.Code
                     });
-                return new LedgerEntryLine(ReconcileStartDate, new List<BankBalance>());
+                return new LedgerEntryLine(ReconcileDate, new List<BankBalance>());
             };
 
-            PrivateAccessor.SetProperty(this.subject, nameof(this.subject.ReconciliationToDoList), testTodoList);
-
+            // Expect a call to the Rule service to create the single use rule for the transfer.
             this.mockRuleService.Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), true))
                 .Returns(new SingleUseMatchingRule(this.bucketRepo));
 
-            this.subject.MonthEndReconciliation(
-                ReconcileStartDate,
-                new List<BankBalance>(),
-                new BudgetCurrencyContext(this.budgetTestData, this.budgetTestData.CurrentActiveBudget),
-                StatementModelTestData.TestData5());
+            Act();
 
+            // Ensure the rule service was called with the appropriate parameters.
             this.mockRuleService.VerifyAll();
         }
 
@@ -64,8 +65,118 @@ namespace BudgetAnalyser.UnitTest.Services
         {
             this.mockLedgerRepo = new Mock<ILedgerBookRepository>();
             this.mockRuleService = new Mock<ITransactionRuleService>(MockBehavior.Strict);
+            this.mockReconciliationConsistency = new Mock<IReconciliationConsistency>();
             this.bucketRepo = new BucketBucketRepoAlwaysFind();
-            this.subject = new LedgerService(this.mockLedgerRepo.Object, new InMemoryAccountTypeRepository(), new FakeLogger(), this.mockRuleService.Object);
+            this.testDataBudgets = BudgetModelTestData.CreateCollectionWith1And2();
+            this.testDataBudgetContext = new BudgetCurrencyContext(this.testDataBudgets, this.testDataBudgets.CurrentActiveBudget);
+            this.testDataStatement = StatementModelTestData.TestData5();
+            this.testDataToDoList = new ToDoCollection();
+            this.subject = new LedgerService(this.mockLedgerRepo.Object, new InMemoryAccountTypeRepository(), new FakeLogger(), this.mockRuleService.Object, this.mockReconciliationConsistency.Object);
+
+            // Inject the preconfigured LedgerBook into the Ledger Service.
+            PrivateAccessor.SetProperty(
+                this.subject,
+                nameof(this.subject.LedgerBook),
+                LedgerBookTestData.TestData5(() => new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object)));
+
+            // Inject the preconfigured to do list into the Ledger Service.
+            PrivateAccessor.SetProperty(this.subject, nameof(this.subject.ReconciliationToDoList), this.testDataToDoList);
+
+            this.mockReconciliationConsistency.Setup(m => m.EnsureConsistency(It.IsAny<LedgerBook>())).Returns(new Mock<IDisposable>().Object);
         }
+
+        private void Act(DateTime? reconciliationDate = null, IEnumerable<BankBalance> bankBalances = null)
+        {
+            var balances = bankBalances ?? NextReconcileBankBalance;
+
+            var ledgerBookTestHarness = (LedgerBookTestHarness)this.subject.LedgerBook;
+            if (ledgerBookTestHarness.ReconcileOverride == null)
+            {
+                ledgerBookTestHarness.ReconcileOverride = () => new LedgerEntryLine(ReconcileDate, balances);
+            }
+
+            this.subject.MonthEndReconciliation(
+                reconciliationDate ?? ReconcileDate,
+                balances,
+                this.testDataBudgetContext,
+                this.testDataStatement);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void UsingInvalidLedgerBook_Reconcile_ShouldThrow()
+        {
+            Act(new DateTime(2012, 02, 20));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ValidationWarningException))]
+        public void UsingTestData1AndNoStatementModelTransactions_Reconcile_ShouldThrow()
+        {
+            this.testDataStatement = new StatementModel(new FakeLogger());
+            Act(new DateTime(2013, 10, 15));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ValidationWarningException))]
+        public void UsingTestData1AndUnclassifiedTransactions_Reconcile_ShouldThrow()
+        {
+            Transaction aTransaction = this.testDataStatement.AllTransactions.Last();
+            PrivateAccessor.SetField(aTransaction, "budgetBucket", null);
+
+            Act(new DateTime(2013, 9, 21));
+        }
+
+        [TestMethod]
+        public void UsingTestData1AndUnclassifiedTransactionsOutsideReconPeriod_Reconcile_ShouldNotThrow()
+        {
+            Transaction aTransaction = this.testDataStatement.AllTransactions.First();
+            PrivateAccessor.SetField(aTransaction, "budgetBucket", null);
+
+            Act(new DateTime(2013, 9, 15));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void UsingTestData1WithDateEqualToExistingLine_Reconcile_ShouldThrow()
+        {
+            Act(new DateTime(2013, 08, 15));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void UsingTestData1WithDateLessThanExistingLine_Reconcile_ShouldThrow()
+        {
+            Act(new DateTime(2013, 07, 15));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ValidationWarningException))]
+        public void UsingTestData5_Reconcile_ShouldThrowWhenAutoMatchingTransactionAreMissingFromStatement()
+        {
+            ActOnTestData5(StatementModelTestData.TestData4());
+            Assert.Fail();
+        }
+
+        private LedgerBook testDataLedgerBook;
+
+        private void ActOnTestData5(StatementModel statementModelTestData = null)
+        {
+            this.testDataLedgerBook = LedgerBookTestData.TestData5();
+            this.testDataBudgets = new BudgetCollection(new [] { BudgetModelTestData.CreateTestData5() });
+            this.testDataBudgetContext = new BudgetCurrencyContext(this.testDataBudgets, this.testDataBudgets.CurrentActiveBudget);
+            this.testDataStatement = statementModelTestData ?? StatementModelTestData.TestData5();
+
+            Console.WriteLine("********************** BEFORE RUNNING RECONCILIATION *******************************");
+            this.testDataStatement.Output(ReconcileDate.AddMonths(-1));
+            this.testDataLedgerBook.Output(true);
+
+            Act(bankBalances: new[] { new BankBalance(StatementModelTestData.ChequeAccount, 1850.5M), new BankBalance(StatementModelTestData.SavingsAccount, 1200M) });
+
+            Console.WriteLine();
+            Console.WriteLine("********************** AFTER RUNNING RECONCILIATION *******************************");
+            this.testDataLedgerBook.Output(true);
+        }
+
     }
 }

--- a/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
@@ -29,7 +29,7 @@ namespace BudgetAnalyser.UnitTest.Services
             var testTodoList = new ToDoCollection();
             PrivateAccessor.SetProperty(this.subject, nameof(this.subject.LedgerBook), new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object));
             PrivateAccessor.SetProperty(this.subject, nameof(this.subject.ReconciliationToDoList), testTodoList);
-            this.mockRuleService.Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), true))
+            this.mockRuleService.Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), true, 2))
                 .Returns(new SingleUseMatchingRule(this.bucketRepo));
 
             this.subject.MonthEndReconciliation(

--- a/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using BudgetAnalyser.Engine.Account;
+using BudgetAnalyser.Engine.Budget;
+using BudgetAnalyser.Engine.Ledger;
+using BudgetAnalyser.Engine.Matching;
+using BudgetAnalyser.Engine.Services;
+using BudgetAnalyser.UnitTest.TestData;
+using BudgetAnalyser.UnitTest.TestHarness;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Rees.TestUtilities;
+
+namespace BudgetAnalyser.UnitTest.Services
+{
+    [TestClass]
+    public class LedgerServiceTest
+    {
+        private static readonly DateTime ReconcileStartDate = new DateTime(2013, 09, 15);
+        private readonly BudgetCollection budgetTestData = BudgetModelTestData.CreateCollectionWith1And2();
+        private IBudgetBucketRepository bucketRepo;
+        private Mock<ILedgerBookRepository> mockLedgerRepo;
+        private Mock<ITransactionRuleService> mockRuleService;
+        private LedgerService subject;
+
+        [TestMethod]
+        public void MonthEndReconciliation_ShouldCreateSingleUseMatchingRulesForTransferToDos()
+        {
+            var testTodoList = new ToDoCollection();
+            PrivateAccessor.SetProperty(this.subject, nameof(this.subject.LedgerBook), new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object));
+            PrivateAccessor.SetProperty(this.subject, nameof(this.subject.ReconciliationToDoList), testTodoList);
+            this.mockRuleService.Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), true))
+                .Returns(new SingleUseMatchingRule(this.bucketRepo));
+
+            this.subject.MonthEndReconciliation(
+                ReconcileStartDate,
+                new List<BankBalance>(),
+                new BudgetCurrencyContext(this.budgetTestData, this.budgetTestData.CurrentActiveBudget),
+                StatementModelTestData.TestData1());
+
+            this.mockRuleService.Verify();
+        }
+
+        [TestInitialize]
+        public void TestIntialise()
+        {
+            this.mockLedgerRepo = new Mock<ILedgerBookRepository>();
+            this.mockRuleService = new Mock<ITransactionRuleService>();
+            this.bucketRepo = new BucketBucketRepoAlwaysFind();
+            this.subject = new LedgerService(this.mockLedgerRepo.Object, new InMemoryAccountTypeRepository(), new FakeLogger(), this.mockRuleService.Object);
+        }
+    }
+}

--- a/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/LedgerServiceTest.cs
@@ -29,7 +29,7 @@ namespace BudgetAnalyser.UnitTest.Services
             var testTodoList = new ToDoCollection();
             PrivateAccessor.SetProperty(this.subject, nameof(this.subject.LedgerBook), new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object));
             PrivateAccessor.SetProperty(this.subject, nameof(this.subject.ReconciliationToDoList), testTodoList);
-            this.mockRuleService.Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), true, 2))
+            this.mockRuleService.Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), true))
                 .Returns(new SingleUseMatchingRule(this.bucketRepo));
 
             this.subject.MonthEndReconciliation(

--- a/BudgetAnalyser.UnitTest/Services/TransactionRuleServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/TransactionRuleServiceTest.cs
@@ -87,7 +87,7 @@ namespace BudgetAnalyser.UnitTest.Services
         private void ArrangeForCreateNewRule()
         {
             this.mockRuleFactory
-                .Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), It.IsAny<bool>()))
+                .Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), It.IsAny<bool>(), 1))
                 .Returns(new SingleUseMatchingRule(this.mockBucketRepo) { BucketCode = "Foo" });
 
             // This is to bypass validating that Initialise has happened when adding a new rule

--- a/BudgetAnalyser.UnitTest/Services/TransactionRuleServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/TransactionRuleServiceTest.cs
@@ -87,7 +87,7 @@ namespace BudgetAnalyser.UnitTest.Services
         private void ArrangeForCreateNewRule()
         {
             this.mockRuleFactory
-                .Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), It.IsAny<bool>(), 1))
+                .Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), It.IsAny<bool>()))
                 .Returns(new SingleUseMatchingRule(this.mockBucketRepo) { BucketCode = "Foo" });
 
             // This is to bypass validating that Initialise has happened when adding a new rule

--- a/BudgetAnalyser.UnitTest/Services/TransactionRuleServiceTest.cs
+++ b/BudgetAnalyser.UnitTest/Services/TransactionRuleServiceTest.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using BudgetAnalyser.Engine.Budget;
+using BudgetAnalyser.Engine.Matching;
+using BudgetAnalyser.Engine.Services;
+using BudgetAnalyser.UnitTest.TestHarness;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Rees.TestUtilities;
+
+namespace BudgetAnalyser.UnitTest.Services
+{
+    [TestClass]
+    public class TransactionRuleServiceTest
+    {
+        private Mock<IMatchmaker> mockMatchMaker;
+        private Mock<IMatchingRuleFactory> mockRuleFactory;
+        private Mock<IMatchingRuleRepository> mockRuleRepo;
+        private IBudgetBucketRepository mockBucketRepo;
+        private TransactionRuleService subject;
+
+        [TestInitialize]
+        public void TestInitialise()
+        {
+            this.mockRuleRepo = new Mock<IMatchingRuleRepository>();
+            this.mockMatchMaker = new Mock<IMatchmaker>();
+            this.mockRuleFactory = new Mock<IMatchingRuleFactory>();
+            this.mockBucketRepo = new BucketBucketRepoAlwaysFind();
+
+            this.subject = new TransactionRuleService(this.mockRuleRepo.Object, new FakeLogger(), this.mockMatchMaker.Object, this.mockRuleFactory.Object);
+        }
+
+        [TestMethod]
+        public void Match_ShouldRemoveSingleUseRulesThatWereUsed()
+        {
+            var testTransactions = TestData.StatementModelTestData.TestData1().Transactions;
+            var testMatchingRules = new List<MatchingRule>()
+            {
+                new SingleUseMatchingRule(this.mockBucketRepo)
+                {
+                    Amount = -95.15M,
+                    And = true,
+                    BucketCode = TestData.StatementModelTestData.PhoneBucket.Code,
+                    Reference1 = "skjghjkh",
+                    MatchCount = 1 // Artificially set to simulate a match
+                },
+                new MatchingRule(this.mockBucketRepo)
+                {
+                    Amount = -11.11M,
+                    BucketCode = TestData.StatementModelTestData.CarMtcBucket.Code,
+                },
+            };
+
+            this.mockMatchMaker.Setup(m => m.Match(testTransactions, testMatchingRules)).Returns(true);
+            PrivateAccessor.InvokeMethod(this.subject, "InitialiseTheRulesCollections", testMatchingRules);
+            PrivateAccessor.SetField<TransactionRuleService>(this.subject, "rulesStorageKey", "lksjgjklshgjkls");
+
+            var success = this.subject.Match(testTransactions);
+            
+            Assert.IsTrue(success);
+            Assert.IsFalse(this.subject.MatchingRules.Any(r => r is SingleUseMatchingRule));
+        }
+
+        [TestMethod]
+        public void CreateNewSingleUseRule_ShouldCallFactoryToCreateTheRule()
+        {
+            ArrangeForCreateNewRule();
+
+            var result = this.subject.CreateNewSingleUseRule("Foo", "Bar", new[] { "Spock", "Kirk" }, "NCC-1701", 1701, true);
+
+            Assert.IsNotNull(result);
+            this.mockRuleFactory.Verify();
+        }
+
+        [TestMethod]
+        public void CreateNewSingleUseRule_ShouldAddRuleToRulesCollection()
+        {
+            ArrangeForCreateNewRule();
+
+            var result = this.subject.CreateNewSingleUseRule("Foo", "Bar", new[] { "Spock", "Kirk" }, "NCC-1701", 1701, true);
+
+            Assert.IsTrue(this.subject.MatchingRules.Any(r => r == result));
+        }
+
+        private void ArrangeForCreateNewRule()
+        {
+            this.mockRuleFactory
+                .Setup(m => m.CreateNewSingleUseRule(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<decimal?>(), It.IsAny<bool>()))
+                .Returns(new SingleUseMatchingRule(this.mockBucketRepo) { BucketCode = "Foo" });
+
+            // This is to bypass validating that Initialise has happened when adding a new rule
+            PrivateAccessor.SetField<TransactionRuleService>(this.subject, "rulesStorageKey", "Anything");
+        }
+    }
+}

--- a/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
+++ b/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
@@ -20,7 +20,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var powerLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PowerBucketCode, "Power ") };
             var phoneLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PhoneBucketCode, "Poo bar") };
 
-            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
+            var book = new LedgerBook(new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Test Data 1 Book",
                 Modified = new DateTime(2013, 12, 16),
@@ -129,7 +129,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var powerLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PowerBucketCode, "Power ") };
             var phoneLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PhoneBucketCode, "Poo bar") };
 
-            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
+            var book = new LedgerBook(new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Test Data 2 Book",
                 Modified = new DateTime(2013, 12, 16),
@@ -246,7 +246,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var clothesLedger = new LedgerBucket { BudgetBucket = new SavedUpForExpenseBucket("CLOTHES", "") };
             var docLedger = new LedgerBucket { BudgetBucket = new SavedUpForExpenseBucket(TestDataConstants.DoctorBucketCode, "") };
 
-            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
+            var book = new LedgerBook(new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Smith Budget 2014",
                 Modified = new DateTime(2013, 12, 22),
@@ -338,7 +338,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var powerLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PowerBucketCode, "Power ") };
             var phoneLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PhoneBucketCode, "Poo bar") };
 
-            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
+            var book = new LedgerBook(new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Test Data 4 Book",
                 Modified = new DateTime(2013, 12, 16),
@@ -471,7 +471,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             }
             else
             {
-                book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()));
+                book = new LedgerBook(new ReconciliationBuilder(new FakeLogger()));
             }
             book.Name = "Test Data 5 Book";
             book.Modified = new DateTime(2013, 12, 16);

--- a/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
+++ b/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
@@ -439,8 +439,6 @@ namespace BudgetAnalyser.UnitTest.TestData
         /// <summary>
         ///     A Test LedgerBook with data populated for June July and August 2013.  Also includes some debit transactions.
         ///     There are multiple Bank Balances for the latest entry, and the Home Insurance bucket in a different account.
-        ///     A Test LedgerBook with data populated for June July and August 2013.  Also includes some debit transactions.
-        ///     August transactions include some balance adjustments.
         /// </summary>
         public static LedgerBook TestData5()
         {

--- a/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
+++ b/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
@@ -20,7 +20,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var powerLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PowerBucketCode, "Power ") };
             var phoneLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PhoneBucketCode, "Poo bar") };
 
-            var book = new LedgerBook(new FakeLogger())
+            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Test Data 1 Book",
                 Modified = new DateTime(2013, 12, 16),
@@ -129,7 +129,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var powerLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PowerBucketCode, "Power ") };
             var phoneLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PhoneBucketCode, "Poo bar") };
 
-            var book = new LedgerBook(new FakeLogger())
+            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Test Data 2 Book",
                 Modified = new DateTime(2013, 12, 16),
@@ -246,7 +246,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var clothesLedger = new LedgerBucket { BudgetBucket = new SavedUpForExpenseBucket("CLOTHES", "") };
             var docLedger = new LedgerBucket { BudgetBucket = new SavedUpForExpenseBucket(TestDataConstants.DoctorBucketCode, "") };
 
-            var book = new LedgerBook(new FakeLogger())
+            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Smith Budget 2014",
                 Modified = new DateTime(2013, 12, 22),
@@ -338,7 +338,7 @@ namespace BudgetAnalyser.UnitTest.TestData
             var powerLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PowerBucketCode, "Power ") };
             var phoneLedger = new LedgerBucket { BudgetBucket = new SpentMonthlyExpenseBucket(TestDataConstants.PhoneBucketCode, "Poo bar") };
 
-            var book = new LedgerBook(new FakeLogger())
+            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Test Data 4 Book",
                 Modified = new DateTime(2013, 12, 16),
@@ -467,7 +467,7 @@ namespace BudgetAnalyser.UnitTest.TestData
                 StoredInAccount = savingsAccount
             };
 
-            var book = new LedgerBook(new FakeLogger())
+            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
             {
                 Name = "Test Data 5 Book",
                 Modified = new DateTime(2013, 12, 16),
@@ -594,7 +594,7 @@ namespace BudgetAnalyser.UnitTest.TestData
 
         private static LedgerEntryLine CreateLine(DateTime date, IEnumerable<BankBalance> bankBalances, string remarks)
         {
-            var line = new LedgerEntryLine(date, bankBalances, new FakeLogger()) { Remarks = remarks };
+            var line = new LedgerEntryLine(date, bankBalances) { Remarks = remarks };
             return line;
         }
 

--- a/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
+++ b/BudgetAnalyser.UnitTest/TestData/LedgerBookTestData.cs
@@ -440,7 +440,7 @@ namespace BudgetAnalyser.UnitTest.TestData
         ///     A Test LedgerBook with data populated for June July and August 2013.  Also includes some debit transactions.
         ///     There are multiple Bank Balances for the latest entry, and the Home Insurance bucket in a different account.
         /// </summary>
-        public static LedgerBook TestData5()
+        public static LedgerBook TestData5(Func<LedgerBook> ctor = null)
         {
             ChequeAccount chequeAccount = StatementModelTestData.ChequeAccount;
             SavingsAccount savingsAccount = StatementModelTestData.SavingsAccount;
@@ -464,13 +464,18 @@ namespace BudgetAnalyser.UnitTest.TestData
                 BudgetBucket = new SavedUpForExpenseBucket(TestDataConstants.InsuranceHomeBucketCode, "Home insurance"),
                 StoredInAccount = savingsAccount
             };
-
-            var book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()))
+            LedgerBook book;
+            if (ctor != null)
             {
-                Name = "Test Data 5 Book",
-                Modified = new DateTime(2013, 12, 16),
-                FileName = "C:\\Folder\\book5.xml"
-            };
+                book = ctor();
+            }
+            else
+            {
+                book = new LedgerBook(new FakeLogger(), new ReconciliationBuilder(new FakeLogger()));
+            }
+            book.Name = "Test Data 5 Book";
+            book.Modified = new DateTime(2013, 12, 16);
+            book.FileName = "C:\\Folder\\book5.xml";
 
             var list = new List<LedgerEntryLine>
             {

--- a/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
+++ b/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using BudgetAnalyser.Engine;
+using BudgetAnalyser.Engine.Annotations;
+using BudgetAnalyser.Engine.Budget;
+using BudgetAnalyser.Engine.Ledger;
+using BudgetAnalyser.Engine.Statement;
+
+namespace BudgetAnalyser.UnitTest.TestHarness
+{
+    public class LedgerBookTestHarness : LedgerBook
+    {
+        /// <summary>
+        /// Constructs a new instance of the <see cref="LedgerBook"/> class.  The Persistence system calls this constructor, not the IoC system. 
+        /// </summary>
+        public LedgerBookTestHarness([NotNull] IReconciliationBuilder reconciliationBuilder) : base(new FakeLogger(), reconciliationBuilder)
+        {
+        }
+
+        internal override LedgerEntryLine Reconcile(
+            DateTime reconciliationStartDate,
+            IEnumerable<BankBalance> currentBankBalances,
+            BudgetModel budget,
+            ToDoCollection toDoList = null,
+            StatementModel statement = null,
+            bool ignoreWarnings = false)
+        {
+            return null;
+        }
+    }
+}

--- a/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
+++ b/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using BudgetAnalyser.Engine;
 using BudgetAnalyser.Engine.Annotations;
 using BudgetAnalyser.Engine.Budget;
 using BudgetAnalyser.Engine.Ledger;
@@ -13,9 +12,12 @@ namespace BudgetAnalyser.UnitTest.TestHarness
         /// <summary>
         /// Constructs a new instance of the <see cref="LedgerBook"/> class.  The Persistence system calls this constructor, not the IoC system. 
         /// </summary>
-        public LedgerBookTestHarness([NotNull] IReconciliationBuilder reconciliationBuilder) : base(new FakeLogger(), reconciliationBuilder)
+        public LedgerBookTestHarness([NotNull] IReconciliationBuilder reconciliationBuilder) 
+            : base(new FakeLogger(), reconciliationBuilder)
         {
         }
+
+        public Func<LedgerEntryLine> ReconcileOverride { get; set; }
 
         internal override LedgerEntryLine Reconcile(
             DateTime reconciliationDate,
@@ -24,7 +26,7 @@ namespace BudgetAnalyser.UnitTest.TestHarness
             ToDoCollection toDoList = null,
             StatementModel statement = null)
         {
-            return null;
+            return ReconcileOverride?.Invoke();
         }
     }
 }

--- a/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
+++ b/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
@@ -13,7 +13,7 @@ namespace BudgetAnalyser.UnitTest.TestHarness
         /// Constructs a new instance of the <see cref="LedgerBook"/> class.  The Persistence system calls this constructor, not the IoC system. 
         /// </summary>
         public LedgerBookTestHarness([NotNull] IReconciliationBuilder reconciliationBuilder) 
-            : base(new FakeLogger(), reconciliationBuilder)
+            : base(reconciliationBuilder)
         {
         }
 

--- a/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
+++ b/BudgetAnalyser.UnitTest/TestHarness/LedgerBookTestHarness.cs
@@ -18,12 +18,11 @@ namespace BudgetAnalyser.UnitTest.TestHarness
         }
 
         internal override LedgerEntryLine Reconcile(
-            DateTime reconciliationStartDate,
+            DateTime reconciliationDate,
             IEnumerable<BankBalance> currentBankBalances,
             BudgetModel budget,
             ToDoCollection toDoList = null,
-            StatementModel statement = null,
-            bool ignoreWarnings = false)
+            StatementModel statement = null)
         {
             return null;
         }

--- a/BudgetAnalyser.UnitTest/TestHarness/XamlOnDiskLedgerBookRepositoryTestHarness.cs
+++ b/BudgetAnalyser.UnitTest/TestHarness/XamlOnDiskLedgerBookRepositoryTestHarness.cs
@@ -14,7 +14,7 @@ namespace BudgetAnalyser.UnitTest.TestHarness
         public XamlOnDiskLedgerBookRepositoryTestHarness(
             [NotNull] BasicMapper<LedgerBookDto, LedgerBook> dataToDomainMapper,
             [NotNull] BasicMapper<LedgerBook, LedgerBookDto> domainToDataMapper
-            ) : base(dataToDomainMapper, domainToDataMapper, new FakeLogger(), new BankImportUtilitiesTestHarness())
+            ) : base(dataToDomainMapper, domainToDataMapper, new BankImportUtilitiesTestHarness(), new LedgerBookFactory(new ReconciliationBuilder(new FakeLogger()), new FakeLogger()))
         {
             LoadXamlFromDiskFromEmbeddedResources = true;
         }

--- a/BudgetAnalyser.UnitTest/Widgets/OverspentWarningTest.cs
+++ b/BudgetAnalyser.UnitTest/Widgets/OverspentWarningTest.cs
@@ -7,6 +7,7 @@ using BudgetAnalyser.Engine.Ledger;
 using BudgetAnalyser.Engine.Statement;
 using BudgetAnalyser.Engine.Widgets;
 using BudgetAnalyser.UnitTest.TestData;
+using BudgetAnalyser.UnitTest.TestHarness;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -29,7 +30,7 @@ namespace BudgetAnalyser.UnitTest.Widgets
             Statement = StatementModelTestData.TestData2();
 
             // Mocking out the Calculator means we dont need the LedgerBook
-            LedgerBook = new Mock<LedgerBook>().Object;
+            LedgerBook = new LedgerBookTestHarness(new Mock<IReconciliationBuilder>().Object);
             SetLedgerBalancesFakeDataSomeOverspentBuckets();
 
             Subject = new OverspentWarning();

--- a/BudgetAnalyser.sln.DotSettings
+++ b/BudgetAnalyser.sln.DotSettings
@@ -678,6 +678,7 @@
 	<s:Boolean x:Key="/Default/Environment/MemoryUsageIndicator/IsVisible/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/TextControl/HighlightCurrentLine/@EntryValue">True</s:Boolean>

--- a/BudgetAnalyser/LedgerBook/LedgerBookController.cs
+++ b/BudgetAnalyser/LedgerBook/LedgerBookController.cs
@@ -199,7 +199,7 @@ namespace BudgetAnalyser.LedgerBook
                     ViewModel.CurrentStatement,
                     ignoreWarnings);
 
-                FileOperations.Dirty = true;
+                FileOperations.ReconciliationChangesWillNeedToBeSaved();
                 NumberOfMonthsToShow++;
                 RaiseLedgerBookUpdated();
                 if (this.ledgerService.ReconciliationToDoList.Any())

--- a/BudgetAnalyser/LedgerBook/LedgerBookControllerFileOperations.cs
+++ b/BudgetAnalyser/LedgerBook/LedgerBookControllerFileOperations.cs
@@ -63,6 +63,13 @@ namespace BudgetAnalyser.LedgerBook
             MessengerInstance.Send(new LedgerBookReadyMessage(null));
         }
 
+        internal void ReconciliationChangesWillNeedToBeSaved()
+        {
+            Dirty = true;
+            this.applicationDatabaseService.NotifyOfChange(ApplicationDataType.MatchingRules);
+            this.applicationDatabaseService.NotifyOfChange(ApplicationDataType.Tasks);
+        }
+
         internal void SyncDataFromLedgerService()
         {
             ViewModel.LedgerBook = LedgerService.LedgerBook;

--- a/BudgetAnalyser/Matching/EditRulesUserControl.xaml
+++ b/BudgetAnalyser/Matching/EditRulesUserControl.xaml
@@ -4,7 +4,6 @@
              xmlns:matching1="clr-namespace:BudgetAnalyser.Matching"
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:budgetAnalyser="clr-namespace:BudgetAnalyser"
              DataContextChanged="OnDataContextChanged">
 
     <UserControl.Resources>
@@ -19,7 +18,7 @@
         </Style>
 
         <DataTemplate DataType="{x:Type matching:MatchingRule}">
-            <Grid>
+            <Grid Visibility="{Binding Hidden, Converter={StaticResource Converter.NotBoolToVis}}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />

--- a/BudgetAnalyser/Matching/NewRuleController.cs
+++ b/BudgetAnalyser/Matching/NewRuleController.cs
@@ -276,7 +276,7 @@ namespace BudgetAnalyser.Matching
             }
 
             NewRule = this.rulesService.CreateNewRule(
-                Bucket,
+                Bucket.Code,
                 UseDescription ? Description : null,
                 new[]
                 {

--- a/BudgetAnalyser/Matching/RulesController.cs
+++ b/BudgetAnalyser/Matching/RulesController.cs
@@ -283,7 +283,7 @@ namespace BudgetAnalyser.Matching
         private void OnNewDataSourceAvailableNotificationReceived(object sender, EventArgs e)
         {
             SortBy = BucketSortKey; // Defaults to Bucket sort order.
-            Rules = new ObservableCollection<MatchingRule>(this.ruleService.MatchingRules.Where(r => !(r is SingleUseMatchingRule)));
+            Rules = this.ruleService.MatchingRules;
             RulesGroupedByBucket = this.ruleService.MatchingRulesGroupedByBucket;
             SelectedRule = null;
             RaisePropertyChanged(() => Rules);

--- a/BudgetAnalyser/Statement/AccountUserControl.xaml.cs
+++ b/BudgetAnalyser/Statement/AccountUserControl.xaml.cs
@@ -14,6 +14,6 @@ namespace BudgetAnalyser.Statement
         }
 
         public Account Account => (Account)DataContext;
-        public string FriendlyAccountName => Account.ToString();
+        public string FriendlyAccountName => Account?.ToString();
     }
 }

--- a/BudgetAnalyser/UI/Style/ListBox.xaml
+++ b/BudgetAnalyser/UI/Style/ListBox.xaml
@@ -60,7 +60,7 @@
     <Style x:Key="ListBox.StandardContainerStyle"
            TargetType="{x:Type ListBoxItem}">
         <Setter Property="Background"
-                Value="{StaticResource Brush.TileBackground}" />
+                Value="Transparent" />
         <Setter Property="SnapsToDevicePixels"
                 Value="True" />
         <Setter Property="HorizontalContentAlignment"


### PR DESCRIPTION
Automatically create single-use matching rules for any system generated transfer task during a reconciliation. This means that when transactions are imported with the system generated code they will automatically be assigned the correct bucket code and the single use rule is discarded.

During a ledger book monthly reconciliation if funds are stored in a different account to the salary account they need to be manually transfered there by the user.  A task list is created during the reconciliation to help with this. Based on this task list single use rules are generated and stored so when the user's transfer shows up in a bank statement import, there is less work for the user to do.